### PR TITLE
DEV-4: Menu Transitions

### DIFF
--- a/Scenes/Components/Back_Button.gd
+++ b/Scenes/Components/Back_Button.gd
@@ -1,23 +1,6 @@
 extends Control
 
-######## WARNING ###########
-# Back_Button MUST!!!!! be a child of a parent with an animation
-# called "start".
-#
-# Back_Button should preferably be the child of the main ui scene.
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	pass # Replace with function body.
-
-func _on_TextureButton_mouse_entered():
-	# Change label outline color to reddish
-	$Button/MarginContainer/Label.add_theme_color_override("font_outline_color", Color(1, 0, 0, 1))
-
-func _on_TextureButton_mouse_exited():
-	# Change label outline back to default
-	pass
-
-func _on_TextureButton_pressed():
+func _on_Back_Button_pressed() -> void:
 	SFXController.playSFX(ReferenceManager.get_reference("back.wav"))
 	get_tree().change_scene_to_file(gamestate.prev_scene)

--- a/Scenes/Components/Back_Button.tscn
+++ b/Scenes/Components/Back_Button.tscn
@@ -1,40 +1,18 @@
-[gd_scene load_steps=8 format=3 uid="uid://b280avyrjcv5t"]
+[gd_scene format=3 uid="uid://b280avyrjcv5t"]
 
 [ext_resource type="Script" uid="uid://cknh2ivvfnojt" path="res://Scenes/Components/Back_Button.gd" id="1"]
-[ext_resource type="FontFile" uid="uid://cxgxlgqxgek6n" path="res://UI/Fonts/Non_Nunito/domino_font/human_domino.otf" id="2"]
-[ext_resource type="Texture2D" uid="uid://bgiplwlfki22u" path="res://UI/Control/red_button10.png" id="3"]
-[ext_resource type="Texture2D" uid="uid://coqqyg76wct3k" path="res://UI/Control/grey_button03.png" id="4"]
-
-[sub_resource type="FontFile" id="1"]
-fallbacks = Array[Font]([ExtResource("2")])
-cache/0/16/0/ascent = 0.0
-cache/0/16/0/descent = 0.0
-cache/0/16/0/underline_position = 0.0
-cache/0/16/0/underline_thickness = 0.0
-cache/0/16/0/scale = 1.0
+[ext_resource type="PackedScene" uid="uid://clj23haf5g65i" path="res://Scenes/Components/AnimatedButton.tscn" id="2_lvnuh"]
 
 [sub_resource type="Animation" id="2"]
 resource_name = "start"
 length = 0.2
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("Button:position")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.2),
-"transitions": PackedFloat32Array(1, 1),
-"update": 0,
-"values": [Vector2(-300, 0), Vector2(0, 0)]
-}
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_kxsim"]
 _data = {
 &"start": SubResource("2")
 }
 
-[node name="Back_Button" type="Control"]
+[node name="Back_Button" type="Control" unique_id=99917349]
 layout_mode = 3
 anchor_right = 0.131
 anchor_bottom = 0.088
@@ -45,51 +23,15 @@ size_flags_vertical = 3
 mouse_filter = 2
 script = ExtResource("1")
 
-[node name="Button" type="TextureButton" parent="."]
-custom_minimum_size = Vector2(100, 50)
+[node name="Back_Button" parent="." unique_id=170246650 instance=ExtResource("2_lvnuh")]
+custom_minimum_size = Vector2(200, 50)
 layout_mode = 0
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = -300.0
-offset_right = -244.0
-size_flags_horizontal = 3
-size_flags_vertical = 3
-mouse_default_cursor_shape = 2
-shortcut_in_tooltip = false
-texture_normal = ExtResource("4")
-texture_hover = ExtResource("3")
-
-[node name="MarginContainer" type="MarginContainer" parent="Button"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_right = -63.0
-offset_bottom = -20.0
-grow_horizontal = 2
-grow_vertical = 2
-scale = Vector2(1.5, 1.5)
-size_flags_horizontal = 3
-size_flags_vertical = 3
-mouse_filter = 2
-theme_override_constants/margin_bottom = 4
-
-[node name="Label" type="Label" parent="Button/MarginContainer"]
-layout_mode = 2
-size_flags_horizontal = 7
-size_flags_vertical = 7
-theme_override_colors/font_color = Color(0.772549, 0, 0, 1)
-theme_override_fonts/font = SubResource("1")
 text = "Back"
-horizontal_alignment = 1
-vertical_alignment = 1
+font_color = Color(0.8862745, 0, 0, 1)
+border_color = Color(0.8862745, 0, 0, 1)
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
-libraries = {
-&"": SubResource("AnimationLibrary_kxsim")
-}
-autoplay = "start"
+[node name="AnimationPlayer" type="AnimationPlayer" parent="." unique_id=1974435690]
+libraries/ = SubResource("AnimationLibrary_kxsim")
+autoplay = &"start"
 
-[connection signal="mouse_entered" from="Button" to="." method="_on_TextureButton_mouse_entered"]
-[connection signal="mouse_exited" from="Button" to="." method="_on_TextureButton_mouse_exited"]
-[connection signal="pressed" from="Button" to="." method="_on_TextureButton_pressed"]
+[connection signal="pressed" from="Back_Button" to="." method="_on_Back_Button_pressed"]

--- a/Scenes/Components/animated_button.gd
+++ b/Scenes/Components/animated_button.gd
@@ -31,7 +31,6 @@ func _ready():
 	var base_style = get_theme_stylebox("normal", "Button")
 	animated_style = base_style.duplicate()
 
-	# Start with no border
 	animated_style.border_width_left = 0
 	animated_style.border_width_right = 0
 	animated_style.border_width_top = 0

--- a/Scenes/Core/Lobby.tscn
+++ b/Scenes/Core/Lobby.tscn
@@ -640,7 +640,6 @@ stretch_mode = 4
 libraries/ = SubResource("AnimationLibrary_u6tgg")
 
 [node name="WaitRoom_Container" type="MarginContainer" parent="." unique_id=287395699]
-visible = false
 layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -798,10 +797,10 @@ anchors_preset = 2
 anchor_top = 1.0
 anchor_right = 0.0
 anchor_bottom = 1.0
-offset_left = 28.8889
-offset_top = 8.66663
-offset_right = 162.889
-offset_bottom = 61.6666
+offset_left = 27.777779
+offset_top = -8.888855
+offset_right = 161.7779
+offset_bottom = 44.111145
 grow_vertical = 0
 
 [connection signal="pressed" from="Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/HBoxContainer/Host" to="." method="_on_Host_pressed"]

--- a/Scenes/Core/Menu_Scene.gd
+++ b/Scenes/Core/Menu_Scene.gd
@@ -5,15 +5,16 @@ var parent
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	parent = get_parent() # Replace with function body.
+	parent = get_parent()
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-#func _process(delta):
-#	pass
 
-func change_scene_with_animation(target_scene):
+func change_scene_with_animation(target_scene, next: bool):
+	
 	# Play transition
-	$Menu_Container/AnimationPlayer.play("transition_out")
+	if next:
+		$Menu_Container/AnimationPlayer.play("next")
+	else:
+		$Menu_Container/AnimationPlayer.play("previous")
 
 	# Wait for transition to finish.
 	await $Menu_Container/AnimationPlayer.animation_finished
@@ -25,14 +26,14 @@ func change_scene_with_animation(target_scene):
 # Load Quit Scene on Quit Button Pressed
 func _on_Quit_Button_pressed():
 	SFXController.playSFX(ReferenceManager.get_reference("back.wav"))
-	change_scene_with_animation(ReferenceManager.get_reference("Quit_Scene.tscn"))
+	change_scene_with_animation(ReferenceManager.get_reference("Quit_Scene.tscn"), false)
 
 # Load Lobby Scene on Play Button pressed
 func _on_Play_Button_pressed():
 	SFXController.playSFX(ReferenceManager.get_reference("next.wav"))
-	change_scene_with_animation(ReferenceManager.get_reference("Lobby.tscn"))
+	change_scene_with_animation(ReferenceManager.get_reference("Lobby.tscn"), true)
 
 # Load Tutorial Scene on Tutorial Button Pressed
 func _on_Tutorial_Button_pressed():
-	SFXController.playSFX(ReferenceManager.get_reference("next.wav")) #Play sound
-	change_scene_with_animation(ReferenceManager.get_reference("Tutorial.tscn"))
+	SFXController.playSFX(ReferenceManager.get_reference("next.wav"))
+	change_scene_with_animation(ReferenceManager.get_reference("Tutorial.tscn"), true)

--- a/Scenes/Core/Menu_Scene.tscn
+++ b/Scenes/Core/Menu_Scene.tscn
@@ -6,40 +6,56 @@
 
 [sub_resource type="Animation" id="6"]
 resource_name = "fall into place"
-length = 0.2
+length = 0.4
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
 tracks/0/path = NodePath(".:position")
-tracks/0/interp = 1
+tracks/0/interp = 2
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.2),
-"transitions": PackedFloat32Array(1, 1),
+"times": PackedFloat32Array(0, 0.4),
+"transitions": PackedFloat32Array(0.5, 1),
 "update": 0,
-"values": [Vector2(0, -600), Vector2(0, 0)]
+"values": [Vector2(0, -550), Vector2(0, 0)]
 }
 
 [sub_resource type="Animation" id="7"]
 resource_name = "transition_out"
-length = 0.2
+length = 0.4
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
 tracks/0/path = NodePath(".:position")
-tracks/0/interp = 1
+tracks/0/interp = 2
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.2),
-"transitions": PackedFloat32Array(1, 1),
+"times": PackedFloat32Array(0, 0.4),
+"transitions": PackedFloat32Array(2, 1),
 "update": 0,
-"values": [Vector2(0, 0), Vector2(0, 600)]
+"values": [Vector2(0, 0), Vector2(0, 550)]
+}
+
+[sub_resource type="Animation" id="Animation_mie7g"]
+length = 0.4
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:position")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.4),
+"transitions": PackedFloat32Array(2, 1),
+"update": 0,
+"values": [Vector2(0, 0), Vector2(0, -550)]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_85wkk"]
 _data = {
-&"fall into place": SubResource("6"),
-&"transition_out": SubResource("7")
+&"in": SubResource("6"),
+&"next": SubResource("7"),
+&"previous": SubResource("Animation_mie7g")
 }
 
 [node name="Menu_Scene" type="Control" unique_id=120761563]
@@ -56,7 +72,7 @@ layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = -2.0
+offset_right = 2.0
 offset_bottom = 18.0
 grow_horizontal = 2
 grow_vertical = 2
@@ -128,7 +144,7 @@ border_color = Color(0.8862745, 0, 0, 1)
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="Menu_Container" unique_id=1286665814]
 libraries/ = SubResource("AnimationLibrary_85wkk")
-autoplay = &"fall into place"
+autoplay = &"in"
 
 [connection signal="pressed" from="Menu_Container/HBoxContainer/MarginContainer2/VBoxContainer/Button_Container/Play_Button" to="." method="_on_Play_Button_pressed"]
 [connection signal="pressed" from="Menu_Container/HBoxContainer/MarginContainer2/VBoxContainer/Button_Container/Tutorial_Button" to="." method="_on_Tutorial_Button_pressed"]

--- a/Scenes/Core/Quit_Scene.gd
+++ b/Scenes/Core/Quit_Scene.gd
@@ -5,7 +5,7 @@ var parent
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	parent = get_parent() # Replace with function body.
+	parent = get_parent()
 
 
 # Quit to desktop
@@ -15,6 +15,12 @@ func _on_Quit_Button_pressed():
 
 # Go back to Menu Scene
 func _on_Cancel_Button_pressed():
+	# Play transition
+	$MarginContainer/AnimationPlayer.play("out")
+
+	# Wait for transition to finish.
+	await $MarginContainer/AnimationPlayer.animation_finished
+	
 	if parent:
 		SFXController.playSFX(ReferenceManager.get_reference("next.wav"))
 		parent.loadForegroundScene(ReferenceManager.get_reference("Menu_Scene.tscn"))

--- a/Scenes/Core/Quit_Scene.tscn
+++ b/Scenes/Core/Quit_Scene.tscn
@@ -191,65 +191,58 @@ cache/0/50/0/underline_position = 0.0
 cache/0/50/0/underline_thickness = 0.0
 cache/0/50/0/scale = 1.0
 
-[sub_resource type="Animation" id="5"]
+[sub_resource type="Animation" id="Animation_8im4j"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(0, 0)]
+}
+
+[sub_resource type="Animation" id="Animation_3amy7"]
+resource_name = "fly_in"
 length = 0.4
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
 tracks/0/path = NodePath(".:position")
-tracks/0/interp = 1
+tracks/0/interp = 2
 tracks/0/loop_wrap = true
 tracks/0/keys = {
 "times": PackedFloat32Array(0, 0.4),
-"transitions": PackedFloat32Array(1, 1),
+"transitions": PackedFloat32Array(0.5, 1),
 "update": 0,
-"values": [Vector2(0, 334), Vector2(0, 900)]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("../Label:position")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.4),
-"transitions": PackedFloat32Array(1, 1),
-"update": 0,
-"values": [Vector2(0, 74), Vector2(0, -500)]
+"values": [Vector2(0, 450), Vector2(0, 0)]
 }
 
-[sub_resource type="Animation" id="4"]
-resource_name = "rise into place"
-length = 0.2
+[sub_resource type="Animation" id="Animation_1wjtl"]
+resource_name = "out"
+length = 0.4
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
 tracks/0/path = NodePath(".:position")
-tracks/0/interp = 1
+tracks/0/interp = 2
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.2),
-"transitions": PackedFloat32Array(1, 1),
+"times": PackedFloat32Array(0, 0.4),
+"transitions": PackedFloat32Array(2, 1),
 "update": 0,
-"values": [Vector2(0, 900), Vector2(0, 334)]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("../Label:position")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.2),
-"transitions": PackedFloat32Array(1, 1),
-"update": 0,
-"values": [Vector2(0, -500), Vector2(0, 74)]
+"values": [Vector2(0, 0), Vector2(0, 450)]
 }
 
-[sub_resource type="AnimationLibrary" id="AnimationLibrary_ag0r0"]
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_1wjtl"]
 _data = {
-&"RESET": SubResource("5"),
-&"rise into place": SubResource("4")
+&"RESET": SubResource("Animation_8im4j"),
+&"in": SubResource("Animation_3amy7"),
+&"out": SubResource("Animation_1wjtl")
 }
 
 [node name="Quit_Scene" type="Control" unique_id=498559685]
@@ -265,6 +258,7 @@ script = ExtResource("7")
 layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
+offset_bottom = 0.00061035156
 theme_override_constants/margin_left = 24
 theme_override_constants/margin_top = 24
 theme_override_constants/margin_right = 24
@@ -272,21 +266,19 @@ theme_override_constants/margin_bottom = 24
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer" unique_id=1675471655]
 layout_mode = 2
+theme_override_constants/separation = 150
 alignment = 1
 
 [node name="Label" type="Label" parent="MarginContainer/VBoxContainer" unique_id=1568165465]
 layout_mode = 2
-size_flags_vertical = 6
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 0.49803922)
+theme_override_constants/shadow_offset_x = 2
+theme_override_constants/shadow_offset_y = 2
 theme_override_fonts/font = SubResource("1")
 theme_override_font_sizes/font_size = 50
 text = "Quit Game?"
 horizontal_alignment = 1
 vertical_alignment = 1
-
-[node name="Separator" type="Control" parent="MarginContainer/VBoxContainer" unique_id=1537161834]
-layout_mode = 2
-size_flags_vertical = 3
-size_flags_stretch_ratio = 0.5
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer" unique_id=1168455765]
 layout_mode = 2
@@ -307,9 +299,9 @@ text = "Quit"
 font_color = Color(0.8862745, 0, 0, 1)
 border_color = Color(0.8862745, 0, 0, 1)
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="MarginContainer/VBoxContainer/HBoxContainer" unique_id=766812540]
-libraries/ = SubResource("AnimationLibrary_ag0r0")
-autoplay = &"rise into place"
+[node name="AnimationPlayer" type="AnimationPlayer" parent="MarginContainer" unique_id=1625497780]
+libraries/ = SubResource("AnimationLibrary_1wjtl")
+autoplay = &"in"
 
 [connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/Cancel_Button" to="." method="_on_Cancel_Button_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/Quit_Button" to="." method="_on_Quit_Button_pressed"]

--- a/Scenes/Core/Title_Scene.gd
+++ b/Scenes/Core/Title_Scene.gd
@@ -1,40 +1,30 @@
 extends Control
 
-# Declare member variables here. Examples:
-# var a = 2
-# var b = "text"
+var input_flag: bool = false
 
-var input_flag = false
 
-func handleChangeToMenuScene():
-	if input_flag == true:
-		return
-		
-	var parent = get_parent()
-	
-	input_flag = true
-	gamestate.title_screen_click_flag = true
-	# Play animation
-	SFXController.playSFX(ReferenceManager.get_reference("next.wav"))
-	$Title_Container/AnimationPlayer.play("Transition")
-	await $Title_Container/AnimationPlayer.animation_finished
-	
-	if parent and parent.has_method("loadForegroundScene"):
-		parent.loadForegroundScene(ReferenceManager.get_reference("Menu_Scene.tscn"))
-		
-# Called when the node enters the scene tree for the first time.
 func _ready():
 	MusicController.playMusic(ReferenceManager.get_reference("quantum.ogg"))
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-#func _process(delta):
-#	pass
 
 func _input(event):
 	if event is InputEventMouseButton:
 		if event.is_pressed():
-			handleChangeToMenuScene()
+			handle_change_to_menu_scene()
 	elif event is InputEventKey:
-		handleChangeToMenuScene()
+		handle_change_to_menu_scene()
 	elif event is InputEventScreenTouch:
-		handleChangeToMenuScene()
+		handle_change_to_menu_scene()
+
+
+func handle_change_to_menu_scene():
+	if input_flag:
+		return
+	var parent = get_parent()
+	input_flag = true
+	gamestate.title_screen_click_flag = true
+	SFXController.playSFX(ReferenceManager.get_reference("next.wav"))
+	$CenterContainer/AnimationPlayer.play("out")
+	await $CenterContainer/AnimationPlayer.animation_finished
+	if parent and parent.has_method("loadForegroundScene"):
+		parent.loadForegroundScene(ReferenceManager.get_reference("Menu_Scene.tscn"))

--- a/Scenes/Core/Title_Scene.tscn
+++ b/Scenes/Core/Title_Scene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://bsxfyv5bnqpoo"]
+[gd_scene format=3 uid="uid://bsxfyv5bnqpoo"]
 
 [ext_resource type="Texture2D" uid="uid://c5yrqg0lncfkt" path="res://UI/sprites/Domino Effect Logo.png" id="2"]
 [ext_resource type="FontFile" uid="uid://cxgxlgqxgek6n" path="res://UI/Fonts/Non_Nunito/domino_font/human_domino.otf" id="3"]
@@ -6,6 +6,15 @@
 
 [sub_resource type="FontFile" id="2"]
 fallbacks = Array[Font]([ExtResource("3")])
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
 cache/0/16/0/ascent = 0.0
 cache/0/16/0/descent = 0.0
 cache/0/16/0/underline_position = 0.0
@@ -331,28 +340,44 @@ _data = {
 &"fade out": SubResource("4")
 }
 
-[sub_resource type="Animation" id="5"]
-resource_name = "Transition"
-length = 0.3
+[sub_resource type="Animation" id="Animation_ck488"]
+length = 0.001
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath(".:position")
+tracks/0/path = NodePath("../../../..:position")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.3),
-"transitions": PackedFloat32Array(1, 1),
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector2(0, 0), Vector2(0, 700)]
+"values": [Vector2(235.99998, 1)]
+}
+
+[sub_resource type="Animation" id="5"]
+resource_name = "Transition"
+length = 0.4
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("../../../..:position")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0.03, 0.4),
+"transitions": PackedFloat32Array(2, 1),
+"update": 0,
+"values": [Vector2(235.99998, 1), Vector2(236, 560)]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_k2au8"]
 _data = {
+&"RESET": SubResource("Animation_ck488"),
 &"Transition": SubResource("5")
 }
 
-[node name="Title_Scene" type="Control"]
+[node name="Title_Scene" type="Control" unique_id=1501407706]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -361,15 +386,15 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("4")
 
-[node name="Title_Container" type="MarginContainer" parent="."]
+[node name="Title_Container" type="MarginContainer" parent="." unique_id=1705217716]
 layout_mode = 1
 anchors_preset = -1
 anchor_left = 0.229
 anchor_right = 0.781
 anchor_bottom = 1.0
-offset_left = 1.50398
+offset_left = 1.5039825
 offset_top = 1.0
-offset_right = 484.256
+offset_right = 484.25598
 offset_bottom = 499.0
 scale = Vector2(0.54, 0.54)
 theme_override_constants/margin_left = 24
@@ -377,21 +402,21 @@ theme_override_constants/margin_top = 24
 theme_override_constants/margin_right = 24
 theme_override_constants/margin_bottom = 24
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Title_Container"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Title_Container" unique_id=109084432]
 layout_mode = 2
 alignment = 1
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Title_Container/HBoxContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Title_Container/HBoxContainer" unique_id=38031083]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_constants/separation = -20
 alignment = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="Title_Container/HBoxContainer/VBoxContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="Title_Container/HBoxContainer/VBoxContainer" unique_id=1378086843]
 layout_mode = 2
 
-[node name="TextureRect" type="TextureRect" parent="Title_Container/HBoxContainer/VBoxContainer/MarginContainer"]
+[node name="TextureRect" type="TextureRect" parent="Title_Container/HBoxContainer/VBoxContainer/MarginContainer" unique_id=371443718]
 custom_minimum_size = Vector2(500, 1000)
 layout_mode = 2
 size_flags_horizontal = 4
@@ -399,23 +424,22 @@ size_flags_vertical = 4
 texture = ExtResource("2")
 stretch_mode = 6
 
-[node name="Label" type="Label" parent="Title_Container/HBoxContainer/VBoxContainer"]
+[node name="Label" type="Label" parent="Title_Container/HBoxContainer/VBoxContainer" unique_id=1805358946]
 layout_mode = 2
 size_flags_horizontal = 7
 size_flags_vertical = 7
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 0.49803922)
+theme_override_constants/shadow_offset_x = 2
+theme_override_constants/shadow_offset_y = 2
 theme_override_fonts/font = SubResource("2")
 theme_override_font_sizes/font_size = 58
 text = "Press anywhere to start."
 horizontal_alignment = 1
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="Title_Container/HBoxContainer/VBoxContainer/Label"]
-libraries = {
-&"": SubResource("AnimationLibrary_m3d3c")
-}
-autoplay = "Text shine"
+[node name="AnimationPlayer" type="AnimationPlayer" parent="Title_Container/HBoxContainer/VBoxContainer/Label" unique_id=531663924]
+libraries/ = SubResource("AnimationLibrary_m3d3c")
+autoplay = &"Text shine"
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="Title_Container"]
+[node name="AnimationPlayer" type="AnimationPlayer" parent="Title_Container" unique_id=1337218037]
 root_node = NodePath("../HBoxContainer/VBoxContainer/MarginContainer/TextureRect")
-libraries = {
-&"": SubResource("AnimationLibrary_k2au8")
-}
+libraries/ = SubResource("AnimationLibrary_k2au8")

--- a/Scenes/Core/Title_Scene.tscn
+++ b/Scenes/Core/Title_Scene.tscn
@@ -301,58 +301,95 @@ cache/0/58/0/underline_position = 0.0
 cache/0/58/0/underline_thickness = 0.0
 cache/0/58/0/scale = 1.0
 
-[sub_resource type="Animation" id="3"]
-resource_name = "Text shine"
-length = 3.0
-loop_mode = 1
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath(".:modulate")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.5, 1, 1.5, 3),
-"transitions": PackedFloat32Array(1, 1, 1, 1, 1),
-"update": 0,
-"values": [Color(1, 1, 1, 1), Color(1, 1, 1, 1), Color(1, 1, 1, 0), Color(1, 1, 1, 1), Color(1, 1, 1, 1)]
-}
-
-[sub_resource type="Animation" id="4"]
-resource_name = "fade out"
-length = 0.3
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath(".:modulate")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.3),
-"transitions": PackedFloat32Array(1, 1),
-"update": 0,
-"values": [Color(1, 1, 1, 1), Color(1, 1, 1, 0)]
-}
-
-[sub_resource type="AnimationLibrary" id="AnimationLibrary_m3d3c"]
-_data = {
-&"Text shine": SubResource("3"),
-&"fade out": SubResource("4")
-}
-
 [sub_resource type="Animation" id="Animation_ck488"]
 length = 0.001
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("../../../..:position")
+tracks/0/path = NodePath("../..:position")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector2(235.99998, 1)]
+"values": [Vector2(0, 0)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath(".:custom_minimum_size")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(500, 500)]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("../Label:modulate")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 1)]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("../..:rotation")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [0.0]
+}
+
+[sub_resource type="Animation" id="Animation_51vco"]
+resource_name = "in"
+length = 2.0
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:custom_minimum_size")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(1, 2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(0, 0), Vector2(500, 500)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("../Label:modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(2),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 0)]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("../..:rotation")
+tracks/2/interp = 2
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(1, 2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [-3.141592653589793, 0.0]
 }
 
 [sub_resource type="Animation" id="5"]
@@ -361,20 +398,39 @@ length = 0.4
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("../../../..:position")
+tracks/0/path = NodePath("../..:position")
 tracks/0/interp = 2
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0.03, 0.4),
+"times": PackedFloat32Array(0, 0.4),
 "transitions": PackedFloat32Array(2, 1),
 "update": 0,
-"values": [Vector2(235.99998, 1), Vector2(236, 560)]
+"values": [Vector2(0, 0), Vector2(0, 550)]
+}
+
+[sub_resource type="Animation" id="Animation_ggl1p"]
+resource_name = "pulse_text"
+length = 2.5
+loop_mode = 1
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("../Label:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.5, 2, 2.5),
+"transitions": PackedFloat32Array(2, 1, 0.5, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1), Color(1, 1, 1, 1), Color(1, 1, 1, 0)]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_k2au8"]
 _data = {
 &"RESET": SubResource("Animation_ck488"),
-&"Transition": SubResource("5")
+&"in": SubResource("Animation_51vco"),
+&"out": SubResource("5"),
+&"pulse_text": SubResource("Animation_ggl1p")
 }
 
 [node name="Title_Scene" type="Control" unique_id=1501407706]
@@ -386,45 +442,35 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("4")
 
-[node name="Title_Container" type="MarginContainer" parent="." unique_id=1705217716]
+[node name="CenterContainer" type="CenterContainer" parent="." unique_id=446058027]
 layout_mode = 1
-anchors_preset = -1
-anchor_left = 0.229
-anchor_right = 0.781
-anchor_bottom = 1.0
-offset_left = 1.5039825
-offset_top = 1.0
-offset_right = 484.25598
-offset_bottom = 499.0
-scale = Vector2(0.54, 0.54)
-theme_override_constants/margin_left = 24
-theme_override_constants/margin_top = 24
-theme_override_constants/margin_right = 24
-theme_override_constants/margin_bottom = 24
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -512.0
+offset_top = -300.0
+offset_right = 512.0
+offset_bottom = 300.0
+grow_horizontal = 2
+grow_vertical = 2
+pivot_offset = Vector2(512, 300)
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Title_Container" unique_id=109084432]
+[node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer" unique_id=38031083]
 layout_mode = 2
-alignment = 1
-
-[node name="VBoxContainer" type="VBoxContainer" parent="Title_Container/HBoxContainer" unique_id=38031083]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
 theme_override_constants/separation = -20
-alignment = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="Title_Container/HBoxContainer/VBoxContainer" unique_id=1378086843]
-layout_mode = 2
-
-[node name="TextureRect" type="TextureRect" parent="Title_Container/HBoxContainer/VBoxContainer/MarginContainer" unique_id=371443718]
-custom_minimum_size = Vector2(500, 1000)
+[node name="TextureRect" type="TextureRect" parent="CenterContainer/VBoxContainer" unique_id=371443718]
+custom_minimum_size = Vector2(500, 500)
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
 texture = ExtResource("2")
-stretch_mode = 6
+expand_mode = 1
+stretch_mode = 4
 
-[node name="Label" type="Label" parent="Title_Container/HBoxContainer/VBoxContainer" unique_id=1805358946]
+[node name="Label" type="Label" parent="CenterContainer/VBoxContainer" unique_id=1805358946]
 layout_mode = 2
 size_flags_horizontal = 7
 size_flags_vertical = 7
@@ -432,14 +478,12 @@ theme_override_colors/font_shadow_color = Color(0, 0, 0, 0.49803922)
 theme_override_constants/shadow_offset_x = 2
 theme_override_constants/shadow_offset_y = 2
 theme_override_fonts/font = SubResource("2")
-theme_override_font_sizes/font_size = 58
+theme_override_font_sizes/font_size = 40
 text = "Press anywhere to start."
 horizontal_alignment = 1
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="Title_Container/HBoxContainer/VBoxContainer/Label" unique_id=531663924]
-libraries/ = SubResource("AnimationLibrary_m3d3c")
-autoplay = &"Text shine"
-
-[node name="AnimationPlayer" type="AnimationPlayer" parent="Title_Container" unique_id=1337218037]
-root_node = NodePath("../HBoxContainer/VBoxContainer/MarginContainer/TextureRect")
+[node name="AnimationPlayer" type="AnimationPlayer" parent="CenterContainer" unique_id=1337218037]
+root_node = NodePath("../VBoxContainer/TextureRect")
 libraries/ = SubResource("AnimationLibrary_k2au8")
+autoplay = &"in"
+next/in = &"pulse_text"


### PR DESCRIPTION
Refine UI transitions by making them cubic as opposed to linear, resulting in smoother transitions. Fix errors with Quit button causing jittering transition. Primary transitions are `Title -> Menu`, `Menu -> Quit`, and `Quit -> Menu`.