### PR TITLE
Fix: Change Master to Main

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -3,7 +3,7 @@ name: ci-dev
 on:
     push:
         branches:
-            - master
+            - main
         paths-ignore:
             - "**.yml"
             - "**.jpg"


### PR DESCRIPTION
Change `master` to `main` in `ci-dev.yml`. This means that the workflow will run whenever code is pushed to the `main` branch.