### PR TITLE
DEV-18: Fix Scaling of Menu Screens

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -37,7 +37,6 @@ ReferenceManager="*res://Autoloads/ReferenceManager.gd"
 window/size/viewport_width=1024
 window/size/viewport_height=600
 window/stretch/mode="canvas_items"
-window/stretch/aspect="expand"
 
 [dotnet]
 


### PR DESCRIPTION
In `Project Settings > General > Display > Window > Stretch > Aspect`, change from `Expand` to `Keep`. This produces letterboxing when the window is resized. This is a typical convention for most video games.

To test, run the project in `Release` mode as opposed to `Debug` mode. To do this, navigate to the project directory in the terminal. Once there, execute the command `godot --path .`. This will run the production version of the application as opposed to using Godot's debugger, which always letterboxes by default.