### PR TITLE
DEV-22: Add Sun Path

### DIFF
--- a/Scenes/Core/Lobby.gd
+++ b/Scenes/Core/Lobby.gd
@@ -14,7 +14,7 @@ var icons_loaded: bool = false
 
 const ICON_NAMES: Array[String] = [
 	"basket.png", "boat.png", "bowandarrow.png", "campfire.png",
-	"fire.png", "spear.png", "stone.png", "sun.png", "sunshine.png", "wheel.png"
+	"fire.png", "spear.png", "stone.png", "wheel.png"
 ]
 
 func _ready():

--- a/Scenes/Core/Lobby.tscn
+++ b/Scenes/Core/Lobby.tscn
@@ -717,7 +717,7 @@ layout_mode = 2
 size_flags_vertical = 0
 theme_override_constants/h_separation = 5
 theme_override_constants/v_separation = 5
-columns = 5
+columns = 4
 
 [node name="VBoxContainer" type="VBoxContainer" parent="WaitRoom_Container/HBoxContainer/MenuContainer/Menu/MarginContainer/VBoxContainer" unique_id=349297613]
 custom_minimum_size = Vector2(0, 150)

--- a/Scenes/Level_4_DominoWorld/DominoWorld.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.gd
@@ -8,7 +8,8 @@ const ROTATION_OFFSET_DEG := 90.0 # rotate pieces 90° clockwise
 
 # --- Hardcoded step directions by path, in degrees ---
 # Order requested: Path1, Path2, Path3?, Path4, Path5, Path6, ?, SunsetPath
-const PATH_ANGLE_DEGREES := [292.5, 247.5, 337.5, 157.5, 112.5, 67.5, 202.5, 22.5]
+#const PATH_ANGLE_DEGREES := [292.5, 247.5, 337.5, 157.5, 112.5, 67.5, 202.5, 22.5]
+const PATH_ANGLE_DEGREES := [292.5, 202.5, 337.5, 157.5, 112.5, 22.5, 247.5, 67.5]
 
 # How far to move each successive domino along that direction
 const STEP_PIXELS := 24.0 # tune for your art scale
@@ -279,13 +280,12 @@ func _init_players() -> void:
 			print(" removed unused ", unused_path)
 
 	# Replace decorative board faces with unused player icons
-	var board_face_nodes := ["sunrise", "sunset"]
+	var board_face_nodes = {"sunrise": "sun.png", "sunset": "sunshine.png"}
 	for node_name in board_face_nodes:
 		var face_sprite := get_node_or_null(node_name)
 		if face_sprite and face_sprite is Sprite2D:
 			var assigned_icon_name: String = my_icon_name
-			if remaining_icon_pool.size() > 0:
-				assigned_icon_name = remaining_icon_pool.pop_front()
+			assigned_icon_name = board_face_nodes[node_name]
 			var ref_key_board := "player_icons/" + assigned_icon_name
 			if ReferenceManager.refDict.has(ref_key_board):
 				var icon_path_board: String = str(ReferenceManager.get_reference(ref_key_board))

--- a/Scenes/Level_4_DominoWorld/DominoWorld.tscn
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.tscn
@@ -321,7 +321,7 @@ texture = null
 
 [node name="Path2" parent="." unique_id=853339331 instance=ExtResource("9")]
 z_index = -2
-position = Vector2(-240, -180)
+position = Vector2(-318, -104.00002)
 scale = Vector2(0.03, 0.03)
 texture = null
 num = 1
@@ -349,21 +349,21 @@ num = 4
 
 [node name="Path6" parent="." unique_id=680097435 instance=ExtResource("9")]
 z_index = -2
-position = Vector2(-138, 86)
+position = Vector2(-57.999992, 9.999996)
 scale = Vector2(0.03, 0.03)
 texture = null
 num = 5
 
 [node name="SunrisePath" parent="." unique_id=453627861 instance=ExtResource("9")]
 z_index = -2
-position = Vector2(-318, -104)
+position = Vector2(-240.00003, -180)
 scale = Vector2(0.03, 0.03)
 texture = null
 num = 6
 
 [node name="SunsetPath" parent="." unique_id=61258073 instance=ExtResource("9")]
 z_index = -2
-position = Vector2(-58, 12)
+position = Vector2(-139, 86.67999)
 scale = Vector2(0.03, 0.03)
 texture = null
 num = 7
@@ -373,20 +373,23 @@ z_index = -1
 position = Vector2(-114, -174)
 scale = Vector2(0.4, 0.4)
 
-[node name="face" parent="Character Bubble1" index="0"]
-position = Vector2(-100, 115)
+[node name="face" parent="Character Bubble1" index="0" unique_id=707796254]
+position = Vector2(-60.9, 35)
 
-[node name="front_hair" parent="Character Bubble1" index="1"]
-position = Vector2(-100, 210)
+[node name="front_hair" parent="Character Bubble1" index="1" unique_id=633581683]
+position = Vector2(-60.9, 130)
 
-[node name="back_hair" parent="Character Bubble1" index="2"]
-position = Vector2(-100, 210)
+[node name="back_hair" parent="Character Bubble1" index="2" unique_id=1771050701]
+position = Vector2(-60.9, 130)
 texture = ExtResource("13")
 
-[node name="CollisionShape2D" parent="Character Bubble1/Area2D" index="0"]
+[node name="Area2D" parent="Character Bubble1" index="3" unique_id=1953206665]
+position = Vector2(39.099995, -79.99999)
+
+[node name="CollisionShape2D" parent="Character Bubble1/Area2D" index="0" unique_id=1168569297]
 position = Vector2(-100, 115)
 
-[node name="Score" parent="Character Bubble1" index="4"]
+[node name="Score" parent="Character Bubble1" index="4" unique_id=1386002985]
 z_index = 2
 
 [node name="Popup" parent="Character Bubble1/Score/Button" index="2"]
@@ -394,38 +397,38 @@ visible = false
 
 [node name="Character Bubble2" parent="." unique_id=917609711 instance=ExtResource("3")]
 z_index = -1
-position = Vector2(-222, -130)
+position = Vector2(-302, -98.00001)
 scale = Vector2(0.4, 0.4)
 
 [node name="Character Bubble3" parent="." unique_id=892282258 instance=ExtResource("3")]
 z_index = -1
-position = Vector2(-110, -78)
+position = Vector2(-72, -92)
 scale = Vector2(0.4, 0.4)
 
 [node name="Character Bubble4" parent="." unique_id=1105370240 instance=ExtResource("3")]
 z_index = -1
-position = Vector2(-270, -16)
+position = Vector2(-306, -9.536743e-07)
 scale = Vector2(0.4, 0.4)
 
 [node name="Character Bubble5" parent="." unique_id=1180595559 instance=ExtResource("3")]
 z_index = -1
-position = Vector2(-224, 30)
+position = Vector2(-240, 66)
 scale = Vector2(0.4, 0.4)
 
 [node name="Character Bubble6" parent="." unique_id=1836691644 instance=ExtResource("3")]
 z_index = -1
-position = Vector2(-160, 30)
+position = Vector2(-77.99999, -4.0000076)
 scale = Vector2(0.4, 0.4)
 
 [node name="sunrise" type="Sprite2D" parent="." unique_id=1731710693]
 z_index = -1
-position = Vector2(-272, -84)
+position = Vector2(-232, -166)
 scale = Vector2(0.25, 0.25)
 texture = ExtResource("4")
 
 [node name="sunset" type="Sprite2D" parent="." unique_id=338479446]
 z_index = -1
-position = Vector2(-112, -12)
+position = Vector2(-146, 66.00001)
 scale = Vector2(0.24, 0.24)
 texture = ExtResource("5")
 
@@ -711,7 +714,7 @@ placed = true
 position = Vector2(8, -112)
 scale = Vector2(0.5, 0.5)
 
-[node name="CollisionShape2D" parent="CentralDomino/Area2D" parent_id_path=PackedInt32Array(20014381, 1374037218) index="0" unique_id=923412705]
+[node name="CollisionShape2D" parent="CentralDomino/Area2D" parent_id_path=PackedInt32Array(2035090892, 1374037218) index="0" unique_id=923412705]
 position = Vector2(8, -112)
 scale = Vector2(0.8, 0.8)
 


### PR DESCRIPTION
Domino trains for the sun path were previously in the following locations: between sections 1 and 2 and between sections 5 and 6. Game documentation indicates the domino trains for the sun path should be between sections 2 and 3 and between sections 6 and 7. This convention correctly communicates that the sun path travels from east to west. The domino trains for the sun path are now in the correct locations. Additionally, users could previously select the sun path icons as their character icon. These specific icons were removed from the icon select screen and are now explicitly assigned to the sun path in the game, meaning the domino trains for the sun path will always be indicated by the sun icons. Lastly, character icons were moved further away from the center of the game board and closer to the player's personal domino train. Footprint tiles would cover character icons once placed, so this convention will enhance the visibility of character icons when footprint tiles are placed.