### PR TITLE
DEV-25: Improve Host/Join UI

### DIFF
--- a/Scenes/Core/Lobby.gd
+++ b/Scenes/Core/Lobby.gd
@@ -33,8 +33,6 @@ func _ready():
 	if has_node("Back_Button"):
 		$Back_Button.pressed.connect(_on_back_button_pressed)
 		
-	# Set the placeholder text to your local IP address
-	$Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/IP/MarginContainer/LineEdit.placeholder_text = get_local_ip()
 	set_player_name(gamestate.player_name)
 
 
@@ -56,7 +54,7 @@ func _on_Join_Button_pressed():
 		SFXController.playSFX(ReferenceManager.get_reference("back.wav"))
 		return
 	
-	var ip = $Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/IP/MarginContainer/LineEdit.text
+	var ip = $Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/HBoxContainer/Join/IP/MarginContainer/LineEdit.text
 	if ip.is_empty():
 		ip = str(local_ip)
 
@@ -83,7 +81,7 @@ func _on_join_timeout():
 func _on_join_accepted():
 	set_error_label("")
 	
-	var ip = $Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/IP/MarginContainer/LineEdit.text
+	var ip = $Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/HBoxContainer/Join/IP/MarginContainer/LineEdit.text
 	if ip.is_empty():
 		ip = str(local_ip)
 		

--- a/Scenes/Core/Lobby.tscn
+++ b/Scenes/Core/Lobby.tscn
@@ -459,53 +459,19 @@ max_length = 32
 expand_to_text_length = true
 clear_button_enabled = true
 
-[node name="IP" type="NinePatchRect" parent="Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer" unique_id=1361729849]
-layout_mode = 2
-size_flags_horizontal = 3
-texture = ExtResource("3")
-region_rect = Rect2(0, 0, 100, 100)
-patch_margin_left = 10
-patch_margin_top = 20
-patch_margin_right = 10
-patch_margin_bottom = 20
-
-[node name="MarginContainer" type="MarginContainer" parent="Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/IP" unique_id=64355400]
-layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -31.09375
-offset_top = -11.0
-offset_right = 31.09375
-offset_bottom = 11.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_constants/margin_left = 8
-theme_override_constants/margin_top = 3
-theme_override_constants/margin_right = 8
-
-[node name="LineEdit" type="LineEdit" parent="Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/IP/MarginContainer" unique_id=598057468]
-layout_mode = 2
-theme = ExtResource("9")
-theme_override_colors/font_placeholder_color = Color(0.6955037, 0.6955029, 0.6955031, 0.6)
-placeholder_text = "IP"
-alignment = 1
-max_length = 32
-expand_to_text_length = true
-clear_button_enabled = true
-
 [node name="HBoxContainer" type="HBoxContainer" parent="Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer" unique_id=1645596931]
 layout_mode = 2
+theme_override_constants/separation = 15
 
 [node name="Host" type="TextureButton" parent="Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/HBoxContainer" unique_id=1266781458]
-custom_minimum_size = Vector2(0, 50)
+custom_minimum_size = Vector2(160, 50)
 layout_mode = 2
+size_flags_vertical = 8
 mouse_default_cursor_shape = 2
 texture_normal = ExtResource("8")
 texture_pressed = ExtResource("4")
 texture_hover = ExtResource("4")
+ignore_texture_size = true
 stretch_mode = 5
 
 [node name="MarginContainer" type="MarginContainer" parent="Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/HBoxContainer/Host" unique_id=140982941]
@@ -522,18 +488,63 @@ text = "Host"
 horizontal_alignment = 1
 vertical_alignment = 1
 
+[node name="VSeparator" type="VSeparator" parent="Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_constants/separation = 20
+
 [node name="Join" type="VBoxContainer" parent="Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/HBoxContainer" unique_id=1782994551]
 layout_mode = 2
+size_flags_horizontal = 3
 theme_override_constants/separation = 15
 
-[node name="Join_Button" type="TextureButton" parent="Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/HBoxContainer/Join" unique_id=1125241492]
-custom_minimum_size = Vector2(0, 50)
+[node name="IP" type="NinePatchRect" parent="Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/HBoxContainer/Join" unique_id=1361729849]
+custom_minimum_size = Vector2(0, 42)
 layout_mode = 2
-size_flags_horizontal = 5
+size_flags_horizontal = 3
+texture = ExtResource("3")
+region_rect = Rect2(0, 0, 100, 100)
+patch_margin_left = 10
+patch_margin_top = 20
+patch_margin_right = 10
+patch_margin_bottom = 20
+
+[node name="MarginContainer" type="MarginContainer" parent="Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/HBoxContainer/Join/IP" unique_id=64355400]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -31.09375
+offset_top = -11.0
+offset_right = 31.09375
+offset_bottom = 11.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 8
+theme_override_constants/margin_top = 3
+theme_override_constants/margin_right = 8
+
+[node name="LineEdit" type="LineEdit" parent="Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/HBoxContainer/Join/IP/MarginContainer" unique_id=598057468]
+layout_mode = 2
+theme = ExtResource("9")
+theme_override_colors/font_placeholder_color = Color(0.6955037, 0.6955029, 0.6955031, 0.6)
+placeholder_text = "IP Address"
+alignment = 1
+max_length = 32
+expand_to_text_length = true
+clear_button_enabled = true
+
+[node name="Join_Button" type="TextureButton" parent="Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/HBoxContainer/Join" unique_id=1125241492]
+custom_minimum_size = Vector2(160, 50)
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 8
 mouse_default_cursor_shape = 2
 texture_normal = ExtResource("5")
 texture_pressed = ExtResource("7")
 texture_hover = ExtResource("7")
+ignore_texture_size = true
 stretch_mode = 5
 
 [node name="MarginContainer" type="MarginContainer" parent="Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/HBoxContainer/Join/Join_Button" unique_id=2118971894]


### PR DESCRIPTION
Previously, the IP Address field in the Host/Join menu appeared to be used for both hosting and joining, but it is actually used only for joining. The hosting automatically uses a suitable address.

To make this more clear, move the IP Address to be above the Join button, and change its placeholder text to simply "IP Address". If left blank, the Join IP still defaults to a local address (which allows easily testing multiple run instances on one machine).