### PR TITLE
DEV-35: Enhance Long Domino Train Visibility

### DIFF
--- a/Scenes/Components/Character Bubble.gd
+++ b/Scenes/Components/Character Bubble.gd
@@ -1,11 +1,11 @@
-# node for characters sitting around game board
 extends Node2D
 
 var my_player_id = null
 
-# Called when the node enters the scene tree for the first time.
+
 func _ready() -> void:
-	pass
+	$Score/Button/Popup.visible = false
+
 
 func setup_character(player_id):
 	my_player_id = player_id
@@ -47,9 +47,10 @@ func setup_character(player_id):
 			var popup_clothes = get_node_or_null("Score/Button/Popup/clothes")
 			if popup_clothes: popup_clothes.texture = load(clothes_path)
 
-# show or hide character stats
+
 func _on_Area2D_mouse_entered() -> void:
 	$Score/Button/Popup.visible = true
-	
+
+
 func _on_Area2D_mouse_exited() -> void:
 	$Score/Button/Popup.visible = false

--- a/Scenes/Components/Character Bubble.gd
+++ b/Scenes/Components/Character Bubble.gd
@@ -4,7 +4,7 @@ var my_player_id = null
 
 
 func _ready() -> void:
-	$Score/Button/Popup.visible = false
+	$Score/Button/Popup.hide()
 
 
 func setup_character(player_id):
@@ -49,8 +49,8 @@ func setup_character(player_id):
 
 
 func _on_Area2D_mouse_entered() -> void:
-	$Score/Button/Popup.visible = true
+	$Score/Button/Popup.popup()
 
 
 func _on_Area2D_mouse_exited() -> void:
-	$Score/Button/Popup.visible = false
+	$Score/Button/Popup.hide()

--- a/Scenes/Components/Character Bubble.tscn
+++ b/Scenes/Components/Character Bubble.tscn
@@ -51,6 +51,23 @@ offset_bottom = 42.0
 
 [node name="Popup" parent="Score/Button" index="2"]
 oversampling_override = 1.0
+position = Vector2i(20, 20)
+size = Vector2i(550, 400)
+
+[node name="Alloy_label" parent="Score/Button/Popup" index="2"]
+horizontal_alignment = 2
+
+[node name="Footprint_label" parent="Score/Button/Popup" index="4"]
+horizontal_alignment = 2
+
+[node name="Wellness_label" parent="Score/Button/Popup" index="6"]
+horizontal_alignment = 2
+
+[node name="Lydia_label" parent="Score/Button/Popup" index="8"]
+offset_left = 286.0
+offset_right = 495.0
+text = "Lydia Lion Coins: "
+horizontal_alignment = 2
 
 [connection signal="mouse_entered" from="Area2D" to="." method="_on_Area2D_mouse_entered"]
 [connection signal="mouse_exited" from="Area2D" to="." method="_on_Area2D_mouse_exited"]

--- a/Scenes/Components/Character Bubble.tscn
+++ b/Scenes/Components/Character Bubble.tscn
@@ -11,6 +11,40 @@ radius = 48.6621
 [node name="Character Bubble" type="Node2D" unique_id=424032425]
 script = ExtResource("2")
 
+[node name="Score" parent="." unique_id=1386002985 instance=ExtResource("3")]
+visible = false
+position = Vector2(-117, 1)
+scale = Vector2(1.1, 1.1)
+
+[node name="Label" parent="Score/Button" index="0"]
+offset_left = 0.0
+offset_right = 92.0
+
+[node name="Points" parent="Score/Button" index="1"]
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 40.0
+offset_bottom = 42.0
+
+[node name="Popup" parent="Score/Button" index="2"]
+oversampling_override = 1.0
+size = Vector2i(550, 400)
+
+[node name="Alloy_label" parent="Score/Button/Popup" index="2"]
+horizontal_alignment = 2
+
+[node name="Footprint_label" parent="Score/Button/Popup" index="4"]
+horizontal_alignment = 2
+
+[node name="Wellness_label" parent="Score/Button/Popup" index="6"]
+horizontal_alignment = 2
+
+[node name="Lydia_label" parent="Score/Button/Popup" index="8"]
+offset_left = 286.0
+offset_right = 495.0
+text = "Lydia Lion Coins: "
+horizontal_alignment = 2
+
 [node name="face" type="Sprite2D" parent="." unique_id=707796254]
 position = Vector2(0.3, 2.09999)
 scale = Vector2(0.6, 0.6)
@@ -33,41 +67,6 @@ texture = ExtResource("5")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D" unique_id=1168569297]
 scale = Vector2(0.5, 0.5)
 shape = SubResource("1")
-
-[node name="Score" parent="." unique_id=1386002985 instance=ExtResource("3")]
-visible = false
-position = Vector2(-117, 1)
-scale = Vector2(1.1, 1.1)
-
-[node name="Label" parent="Score/Button" index="0"]
-offset_left = 0.0
-offset_right = 92.0
-
-[node name="Points" parent="Score/Button" index="1"]
-offset_left = 0.0
-offset_top = 0.0
-offset_right = 40.0
-offset_bottom = 42.0
-
-[node name="Popup" parent="Score/Button" index="2"]
-oversampling_override = 1.0
-position = Vector2i(20, 20)
-size = Vector2i(550, 400)
-
-[node name="Alloy_label" parent="Score/Button/Popup" index="2"]
-horizontal_alignment = 2
-
-[node name="Footprint_label" parent="Score/Button/Popup" index="4"]
-horizontal_alignment = 2
-
-[node name="Wellness_label" parent="Score/Button/Popup" index="6"]
-horizontal_alignment = 2
-
-[node name="Lydia_label" parent="Score/Button/Popup" index="8"]
-offset_left = 286.0
-offset_right = 495.0
-text = "Lydia Lion Coins: "
-horizontal_alignment = 2
 
 [connection signal="mouse_entered" from="Area2D" to="." method="_on_Area2D_mouse_entered"]
 [connection signal="mouse_exited" from="Area2D" to="." method="_on_Area2D_mouse_exited"]

--- a/Scenes/Components/Domino.gd
+++ b/Scenes/Components/Domino.gd
@@ -1,4 +1,3 @@
-# node for domino on Domino Level
 class_name Domino
 extends Node2D
 
@@ -6,45 +5,35 @@ extends Node2D
 @export var bottom_num = 0
 @export var top_element = ""
 @export var bottom_element = ""
-
-
 @export var original_pos = null
+@export var placed = false
+@export var hand_hover_mult := 1.10
+@export var placed_hover_mult := 3
+
+@onready var sprite: Sprite2D = $Sprite2D
+@onready var label: Label = $Label
+
 var _orig_y_sort := false
 var _orig_z := 0
-# Affects the Domino hand as well
-#var og_scale = .5 # Hard coded to fit scale of CentralDomino Node2D in DominoWorld.tscn
-#var hover_scale = og_scale + .05
-
 var selected = false
-@export var placed = false
-
-# NEW: separate hover multipliers for hand vs. placed
-@export var hand_hover_mult := 1.10 # 10% bump in the hand
-@export var placed_hover_mult := 3 # 300% bump on the board
-
-# Track the node’s base scale so we can return to it on mouse exit
 var _base_scale: Vector2 = Vector2.ONE
-
-# Reference to world node to minimize `get_parent()` calls
 var _world = null
 
-# Called when the node enters the scene tree for the first time.
+
 func _ready() -> void:
-	$Sprite2D.z_as_relative = true
-	$Sprite2D.top_level = false
-	$Sprite2D.z_index = 0
-	_world = get_parent()
-	# change domino appearance
+	sprite.z_as_relative = true
+	sprite.top_level = false
+	sprite.z_index = 0
+	_world = get_parent().get_parent()
 	if not placed:
 		add_to_group("dominos")
-	# Set initial scale to og_scale
-	#$Sprite2D.scale = Vector2(og_scale, og_scale)
-	# Store original position for reference
 	original_pos = position
 	call_deferred("_capture_base_scale")
 
+
 func _capture_base_scale() -> void:
 	_base_scale = scale
+
 
 func init(bottom, top, bottom_elm, top_elm, initial):
 	bottom_num = bottom
@@ -60,18 +49,18 @@ func init(bottom, top, bottom_elm, top_elm, initial):
 		top_element = top_elm
 	if initial:
 		original_pos = self.position
-	$Label.text = bottom_element + "\n" + str(bottom) + " | " + str(top) + "\n" + top_element
+	label.text = bottom_element + "\n" + str(bottom) + " | " + str(top) + "\n" + top_element
 
 
-# NEW: let the world update our notion of base scale when it changes the node scale
 func set_base_scale(new_scale: Vector2) -> void:
 	scale = new_scale
 	_base_scale = new_scale
 
-# NEW: helper called when a domino becomes placed
+
 func mark_as_placed(new_scale: Vector2) -> void:
 	placed = true
 	set_base_scale(new_scale)
+
 
 func _on_Area2D_mouse_entered() -> void:
 	var mult: float
@@ -86,6 +75,7 @@ func _on_Area2D_mouse_entered() -> void:
 	y_sort_enabled = false
 	_orig_z = z_index
 	z_index = 10 # put it on top
+
 
 func _on_Area2D_mouse_exited() -> void:
 	scale = _base_scale
@@ -128,10 +118,12 @@ func swap(other: Domino) -> void:
 	original_pos = position
 	other.original_pos = other.position
 
+
 func deselect() -> void:
 	selected = false
 	if !placed:
 		position = original_pos
+
 
 func get_domino_at_click() -> Domino:
 	var mouse_pos = get_global_mouse_position()
@@ -153,10 +145,9 @@ func get_domino_at_click() -> Domino:
 			return node
 	return null
 
+
 func _physics_process(_delta):
 	if selected and not placed:
 		var mousePos = get_global_mouse_position()
-		position.x = 2 * mousePos.x;
-		position.y = 2 * mousePos.y;
-	# elif not placed:
-	# 	position = original_pos
+		position.x = mousePos.x;
+		position.y = mousePos.y;

--- a/Scenes/Components/Path.gd
+++ b/Scenes/Components/Path.gd
@@ -25,11 +25,13 @@ var _glow_time := 0.0
 func _ready() -> void:
 	_base_scale = scale  # captures 0.03 from scene instance
 	set_process(false)
-	get_parent().add_position(self.position)
+	get_parent().get_parent().add_position(self.position)
+
 
 func _process(delta: float) -> void:
 	_glow_time += delta
 	queue_redraw()
+
 
 func _draw() -> void:
 	if not _indicator_active:
@@ -86,7 +88,7 @@ func _update_visual() -> void:
 func _on_Area2D_input_event(viewport: Node, event: InputEvent, shape_idx: int) -> void:
 	if event is InputEventMouseButton:
 		if event.pressed:
-			get_parent().place_domino(num)
+			get_parent().get_parent().place_domino(num)
 
 func _on_Area2D_mouse_entered() -> void:
 	if not _indicator_active:

--- a/Scenes/Level_4_DominoWorld/DominoWorld.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.gd
@@ -1,70 +1,55 @@
-# domino level scene
 class_name DominoWorld
 extends Node2D
 
-const HAND_SCALE = Vector2(0.22, 0.22)
-const PLACED_SCALE = Vector2(0.08, 0.08)
-const ROTATION_OFFSET_DEG := 90.0 # rotate pieces 90° clockwise
-const HAND_SPACING := 85 # pixels between hand dominoes
-
-# --- Hardcoded step directions by path, in degrees ---
-# Order requested: Path1, Path2, Path3?, Path4, Path5, Path6, ?, SunsetPath
-#const PATH_ANGLE_DEGREES := [292.5, 247.5, 337.5, 157.5, 112.5, 67.5, 202.5, 22.5]
-const PATH_ANGLE_DEGREES := [292.5, 202.5, 337.5, 157.5, 112.5, 22.5, 247.5, 67.5]
-
-# How far to move each successive domino along that direction
-const STEP_PIXELS := 24.0 # tune for your art scale
-
-# Keep a per-path step count; replaces placed_domino_offset
-var path_step_count := [0, 0, 0, 0, 0, 0, 0, 0]
-# Tracks which player trains (0-5) are currently open for anyone to play on
-var train_open := [false, false, false, false, false, false, false, false]
-
 @export var Domino: PackedScene
-# NOTE: If domino game performance is low, try switching to preload
-#const FootprintTile = preload("res://Scenes/Level_4_DominoWorld/FootprintTile.gd")
+
+@onready var central_domino = $WorldElements/CentralDomino
+@onready var board = $WorldElements/Board
+@onready var camera = $WorldElements/Camera2D
+@onready var world_elements = $WorldElements
+
+@onready var start_button = $UIElements/HUD/BottomPanel/Start
+@onready var next_button = $UIElements/HUD/TopPanel/Next
+@onready var help_button = $UIElements/HUD/BottomPanel/Help
+@onready var reset_button = $UIElements/HUD/BottomPanel/Reset
+@onready var turn_label = $UIElements/HUD/TopPanel/Turn
+@onready var place_sound = $UIElements/Place
+@onready var acquire_sound = $UIElements/Acquire
+@onready var end_label = $UIElements/HUD/End
+@onready var ui_elements = $UIElements
+
+const HAND_SCALE = Vector2(0.44, 0.44)
+const PLACED_SCALE = Vector2(0.08, 0.08)
+const ROTATION_OFFSET_DEG := 90.0
+const HAND_SPACING := 170
+const HAND_CENTER_X: int = 1024
+const HAND_CENTER_Y: int = 1000
+const PATH_ANGLE_DEGREES := [292.5, 202.5, 337.5, 157.5, 112.5, 22.5, 247.5, 67.5]
+const STEP_PIXELS := 24.0
+
+var path_step_count := [0, 0, 0, 0, 0, 0, 0, 0]
+var train_open := [false, false, false, false, false, false, false, false]
 var FootprintTile = load(ReferenceManager.get_reference("FootprintTile.gd"))
 var footprint_tile_ring = null
-# NOTE: If domino game performance is low, try switching to preload
-#const tower = preload("res://Scenes/Level_4_DominoWorld/Tower.gd")
 var tower = load(ReferenceManager.get_reference("Tower.gd"))
 var sorted_players = []
-
-var turn = 0 # whose turn is it, indexed from 0 on
+var turn = 0
 var hand = []
 var dominos = [] + gamestate.dominos
-var self_num = 0 # player's number, indexed from 1 on
-var selected_domino = null # currently selected domino
-var center_num = 0 # current round number
+var self_num = 0
+var selected_domino = null
+var center_num = 0
 var num_placed = 0
-
-var cpu_hands = {} # The Host stores CPU hands here
-
-# (Fall 2025) added variables
-var can_place = true # to check if currently selected domino is a double
-var hand_dominos = [] # track dominos in hand numerically
-
-var path_ends = [0, 0, 0, 0, 0, 0, 0, 0] # last number on domino chain in each path
-var end_dominos = [null, null, null, null, null, null, null, null] # last domino on domino chain in each path
-
+var cpu_hands = {}
+var can_place = true
+var hand_dominos = []
+var path_ends = [0, 0, 0, 0, 0, 0, 0, 0]
+var end_dominos = [null, null, null, null, null, null, null, null]
 var position_table: Array[Vector2] = []
 var prev_domino_size = 0
 var _next_slot_indicators: Array[Node2D] = []
-
 var bonusWords = ["Bonus", "Bonus2"]
 var usedBonus = ["ABC123"]
-
-@onready var start_button = $WorldElements/Start
-@onready var next_button = $WorldElements/Next
-@onready var help_button = $WorldElements/Help
-@onready var reset_button = $WorldElements/Reset
-@onready var central_domino = $WorldElements/CentralDomino
-@onready var board = $WorldElements/Board
-
-@onready var turn_label = $UIElements/Turn
-@onready var place_sound = $UIElements/Place
-@onready var acquire_sound = $UIElements/Acquire
-@onready var end_label = $UIElements/End
 
 
 func _ready() -> void:
@@ -118,9 +103,9 @@ func _init_players() -> void:
 
 	# Shuffle for icons not chosen by players
 	var remaining_icon_pool: Array[String] = []
-	for name in all_icon_names:
-		if chosen_icon_names.find(name) == -1:
-			remaining_icon_pool.append(name)
+	for icon_name in all_icon_names:
+		if chosen_icon_names.find(icon_name) == -1:
+			remaining_icon_pool.append(icon_name)
 	remaining_icon_pool.shuffle()
 
 	# Reserve local player's chosen icon (fallback to basket.png)
@@ -335,7 +320,7 @@ func _init_players() -> void:
 	# Host sees Start button
 	if multiplayer.get_unique_id() == 1:
 		start_button.visible = true
-		print("Host detected, Start button visible")
+		print("Host detected, Start button visible at", start_button.position)
 
 	print("Turn label set to ", turn_label.text)
 	print("=== _init_players() END ===")
@@ -407,8 +392,8 @@ func setup_dominos():
 	# Render the host's hand locally
 	render_hand(my_hand)
 
-@rpc("any_peer") func receive_hand(hand):
-	render_hand(hand)
+@rpc("any_peer") func receive_hand(domino_hand):
+	render_hand(domino_hand)
 
 @rpc("authority", "call_remote") func sync_full_deck(new_deck):
 	dominos = new_deck
@@ -435,13 +420,12 @@ func render_hand(drawn_dominos):
 		var domino = Domino.instantiate()
 		var domino_title = str(domino_nums[1]) + str(domino_nums[0])
 		domino.get_node("Sprite2D").texture = load(ReferenceManager.get_reference("dominos/" + domino_title + ".png"))
-		add_child(domino)
+		ui_elements.add_child(domino)
 
 		# set domino position and scale
 		var hand_count = drawn_dominos.size()
 		var total_width = (hand_count - 1) * HAND_SPACING
-		var hand_center_x = -192.0
-		domino.position = Vector2(hand_center_x + (i * HAND_SPACING) - (total_width / 2.0), 175)
+		domino.position = Vector2(HAND_CENTER_X + (i * HAND_SPACING) - (total_width / 2.0), HAND_CENTER_Y)
 		domino.scale = HAND_SCALE
 		domino.rotation_degrees = 270
 
@@ -471,9 +455,8 @@ func rearrange_hand() -> void:
 	if hand_count == 0:
 		return
 	var total_width: float = (hand_count - 1) * HAND_SPACING
-	var hand_center_x: float = -192.0
 	for i in range(hand_count):
-		var new_pos := Vector2(hand_center_x + (i * HAND_SPACING) - (total_width / 2.0), 175)
+		var new_pos := Vector2(HAND_CENTER_X + (i * HAND_SPACING) - (total_width / 2.0), HAND_CENTER_Y)
 		unplaced[i].position = new_pos
 		unplaced[i].original_pos = new_pos
 
@@ -575,9 +558,12 @@ func place_domino(num):
 			selected_domino.get_node("Sprite2D").rotation_degrees = 0
 
 		# Place locally
+		ui_elements.remove_child(selected_domino)
+		world_elements.add_child(selected_domino)
 		selected_domino.mark_as_placed(PLACED_SCALE)
 		selected_domino.global_position = _path_position_for_step(num, path_step_count[num])
 		_orient_to_path(selected_domino, num)
+		camera.set_drag(false)
 
 		# Update path ends
 		if flip:
@@ -714,10 +700,8 @@ func increment_total(num):
 
 # display wellness bead popup
 func display_wellness_prompt():
-	$UIElements/WellnessBeadPopup/Title.text = "You Got a..."
-	$UIElements/WellnessBeadPopup/WellnessBead.text = "Wellness Bead!"
-	$UIElements/WellnessBeadPopup/Info.text = "You helped someone on their path and so helped promote community wellness!"
 	$UIElements/WellnessBeadPopup.visible = true
+	camera.set_drag(false)
 
 
 # increment wellness beads for player denoted by num
@@ -739,6 +723,7 @@ func display_wellness_prompt():
 	$UIElements/AlloyPopup/Alloy.text = alloy
 	$UIElements/AlloyPopup/Info.text = curriculum.alloy_table[alloy]
 	$UIElements/AlloyPopup.visible = true
+	camera.set_drag(false)
 
 
 # increment footprint tiles earned for player denoted by player_num
@@ -767,6 +752,7 @@ func display_footprint_tile(round_num: int, footprint_num: int) -> void:
 			$UIElements/FootprintTilePopup/Info.text = curriculum.footprint_text_table[table_index]
 			$UIElements/FootprintTilePopup/Description.text = ""
 		$UIElements/FootprintTilePopup.visible = true
+		camera.set_drag(false)
 
 # update domino path for all players after a player places a domino
 @rpc("any_peer") func update_domino_path(domino_nums, domino_elms, pos, path_num, flip):
@@ -930,7 +916,7 @@ func _update_turn_label():
 	var current_player_id = sorted_players[turn]
 	var current_name = gamestate.players[current_player_id]
 	
-	turn_label.text = current_name + "'s\nTurn"
+	turn_label.text = current_name + "'s Turn"
 	# Only show the "Need Help" button if it is currently YOUR turn
 	help_button.visible = (turn == self_num)
 	
@@ -1099,11 +1085,11 @@ func determine_winner():
 	var winners = []
 	for i in range(1, len(sorted_players) + 1):
 		var current_player = get_node("WorldElements/Character Bubble" + str(i) + "/Score/Button/Popup")
-		if int(current_player.get_node("WorldElements/Lydia_number").text) > best_score:
-			winners = [current_player.get_node("WorldElements/Name_text").text]
-			best_score = int(current_player.get_node("WorldElements/Lydia_number").text)
-		elif int(current_player.get_node("WorldElements/Lydia_number").text) == best_score:
-			winners.append(current_player.get_node("WorldElements/Name_text").text)
+		if int(current_player.get_node("Lydia_number").text) > best_score:
+			winners = [current_player.get_node("Name_text").text]
+			best_score = int(current_player.get_node("Lydia_number").text)
+		elif int(current_player.get_node("Lydia_number").text) == best_score:
+			winners.append(current_player.get_node("Name_text").text)
 	var winner_text = ""
 	for winner in winners:
 		winner_text += winner
@@ -1154,52 +1140,11 @@ var grey = Color("aaaaaa")
 
 
 func _on_EnterCode_mouse_entered():
-	$WorldElements/Code/MarginContainer/Label.set("theme_override_colors/font_color", green)
+	$UIElements/Code/MarginContainer/Label.set("theme_override_colors/font_color", green)
 
 
 func _on_EnterCode_mouse_exited():
-	$WorldElements/Code/MarginContainer/Label.set("theme_override_colors/font_color", grey)
-
-
-func _on_Next_mouse_entered():
-	$WorldElements/Next/MarginContainer/Label.set("theme_override_colors/font_color", green)
-
-
-func _on_Next_mouse_exited():
-	$WorldElements/Next/MarginContainer/Label.set("theme_override_colors/font_color", grey)
-
-
-func _on_Help_mouse_entered():
-	$WorldElements/Help/MarginContainer/Label.set("theme_override_colors/font_color", green)
-
-
-func _on_Help_mouse_exited():
-	$WorldElements/Help/MarginContainer/Label.set("theme_override_colors/font_color", grey)
-
-
-func _on_Reset_mouse_entered():
-	$WorldElements/Reset/MarginContainer/Label.set("theme_override_colors/font_color", green)
-
-
-func _on_Reset_mouse_exited():
-	$WorldElements/Reset/MarginContainer/Label.set("theme_override_colors/font_color", grey)
-
-
-func _on_Start_mouse_entered():
-	$WorldElements/Start/MarginContainer/Label.set("theme_override_colors/font_color", green)
-
-
-func _on_Start_mouse_exited():
-	$WorldElements/Start/MarginContainer/Label.set("theme_override_colors/font_color", grey)
-
-
-func _on_HelpButton_pressed():
-	$WorldElements/HelpMenu/HelpImage.visible = true
-	$WorldElements/HelpMenu.move_to_front()
-
-
-func _on_CloseButton_pressed():
-	$WorldElements/HelpMenu/HelpImage.visible = false
+	$UIElements/Code/MarginContainer/Label.set("theme_override_colors/font_color", grey)
 
 
 func _deg_to_vec2(angle_deg: float) -> Vector2:
@@ -1247,9 +1192,11 @@ class _NextSlotIndicator extends Node2D:
 	var _path_num: int
 	var _glow_time := 0.0
 
+
 	func _init(color: Color, path_num: int) -> void:
 		_color = color
 		_path_num = path_num
+
 
 	func _ready() -> void:
 		# Add an Area2D with a RectangleShape2D so mouse clicks are detected.
@@ -1264,13 +1211,16 @@ class _NextSlotIndicator extends Node2D:
 		add_child(area)
 		area.input_event.connect(_on_area_input_event)
 
+
 	func _on_area_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
 		if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
 			get_parent().place_domino(_path_num)
 
+
 	func _process(delta: float) -> void:
 		_glow_time += delta
 		queue_redraw()
+
 
 	func _draw() -> void:
 		# Slightly smaller than Path.gd indicator (0.85x) to signal "preview/future"

--- a/Scenes/Level_4_DominoWorld/DominoWorld.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.gd
@@ -54,29 +54,40 @@ var _next_slot_indicators: Array[Node2D] = []
 var bonusWords = ["Bonus", "Bonus2"]
 var usedBonus = ["ABC123"]
 
-# Called when the node enters the scene tree for the first time.
+@onready var start_button = $WorldElements/Start
+@onready var next_button = $WorldElements/Next
+@onready var help_button = $WorldElements/Help
+@onready var reset_button = $WorldElements/Reset
+@onready var central_domino = $WorldElements/CentralDomino
+@onready var board = $WorldElements/Board
+
+@onready var turn_label = $UIElements/Turn
+@onready var place_sound = $UIElements/Place
+@onready var acquire_sound = $UIElements/Acquire
+@onready var end_label = $UIElements/End
+
+
 func _ready() -> void:
-	$Start.visible = false
-	$Next.visible = false
-	# (Fall 2025) set the visibility of added buttons accordingly
-	$Help.visible = false
-	$Reset.visible = false
+	start_button.visible = false
+	next_button.visible = false
+	help_button.visible = false
+	reset_button.visible = false
 	intialize_tower()
 	_init_players()
 	dominos.erase([0, 0])
 	
-	var center_area := $CentralDomino.get_node_or_null("Area2D")
+	var center_area := central_domino.get_node_or_null("Area2D")
 	if center_area:
 		center_area.input_pickable = false
 		center_area.monitoring = false
-		
-#  Sets up and resolves players and their resulting nodes
+
+# Sets up and resolves players and their resulting nodes
 func _init_players() -> void:
 	print("=== _init_players() START ===")
 	
 	# initialize footprint tile ring
 	footprint_tile_ring = load(ReferenceManager.get_reference("FootprintTileRing.gd")).new(self)
-	footprint_tile_ring.position = $Board.position
+	footprint_tile_ring.position = board.position
 	add_child(footprint_tile_ring)
 	print("Added footprint_tile_ring at: ", footprint_tile_ring.position)
 
@@ -121,7 +132,7 @@ func _init_players() -> void:
 	var ind := 1
 
 	for player_id in sorted_players:
-		var bubble_path := "Character Bubble" + str(ind)
+		var bubble_path := "WorldElements/Character Bubble" + str(ind)
 		print("\n--- setting up ", bubble_path, " for player_id=", player_id, " ---")
 		
 		var bubble_node = get_node_or_null(bubble_path)
@@ -263,7 +274,7 @@ func _init_players() -> void:
 		# self / path visibility logic (unchanged)
 		if player_id == multiplayer.get_unique_id():
 			self_num = ind - 1
-			var path_node_self = get_node_or_null("Path" + str(ind))
+			var path_node_self = get_node_or_null("WorldElements/Path" + str(ind))
 			if path_node_self:
 				path_node_self.visible = true
 				print(" made Path", ind, " visible for SELF")
@@ -272,7 +283,7 @@ func _init_players() -> void:
 				for child in get_children():
 					print("    child: ", child.name)
 		else:
-			var other_path_node = get_node_or_null("Path" + str(ind))
+			var other_path_node = get_node_or_null("WorldElements/Path" + str(ind))
 			if other_path_node:
 				other_path_node.temp = true
 				print(" marked Path", ind, " as temp for OTHER")
@@ -281,7 +292,7 @@ func _init_players() -> void:
 
 	# remove any unused character sprites
 	for i in range(ind, 7):
-		var unused_path := "Character Bubble" + str(i)
+		var unused_path := "WorldElements/Character Bubble" + str(i)
 		if has_node(unused_path):
 			get_node(unused_path).queue_free()
 			print(" removed unused ", unused_path)
@@ -289,7 +300,7 @@ func _init_players() -> void:
 	# Replace decorative board faces with unused player icons
 	var board_face_nodes = {"sunrise": "sun.png", "sunset": "sunshine.png"}
 	for node_name in board_face_nodes:
-		var face_sprite := get_node_or_null(node_name)
+		var face_sprite := get_node_or_null("WorldElements/" + node_name)
 		if face_sprite and face_sprite is Sprite2D:
 			var assigned_icon_name: String = my_icon_name
 			assigned_icon_name = board_face_nodes[node_name]
@@ -323,10 +334,10 @@ func _init_players() -> void:
 
 	# Host sees Start button
 	if multiplayer.get_unique_id() == 1:
-		$Start.visible = true
+		start_button.visible = true
 		print("Host detected, Start button visible")
 
-	print("Turn label set to ", $Turn.text)
+	print("Turn label set to ", turn_label.text)
 	print("=== _init_players() END ===")
 
 
@@ -340,10 +351,10 @@ func _on_Start_pressed() -> void:
 	randomize_turn()
 		
 	setup_dominos()
-	$Start.queue_free()
+	start_button.queue_free()
 	
 	if (self_num == 0):
-		$Next.visible = true
+		next_button.visible = true
 		
 	SFXController.playSFX(ReferenceManager.get_reference("next.wav"))
 
@@ -474,12 +485,8 @@ func add_position(global_pos: Vector2) -> void:
 # take a domino from the main deck
 func draw_domino():
 	var nums = dominos.pop_front()
-	# print("len: ", len(dominos))
 	if nums[0] < nums[1]:
 		nums.reverse()
-	# print(nums, len(dominos))
-
-	# update every player's deck to stay in sync
 	rpc("update_deck")
 	return nums
 
@@ -498,11 +505,8 @@ func is_domino_selected(domino) -> bool:
 
 # Attempt to select domino. Return true if successful.
 func select_domino(domino) -> bool:
-	# (Fall 2025) added to restrict more than 1 domino being placed a turn if its not a double
 	if (can_place == false):
-		print("Cannot place anymore this turn") # debug
 		return false
-		
 	if selected_domino == null:
 		selected_domino = domino
 	if selected_domino == domino:
@@ -603,7 +607,7 @@ func place_domino(num):
 			can_place = false
 			
 		clear_selected_domino()
-		$Place.playing = true
+		place_sound.playing = true
 		
 		if not can_place:
 			rpc("advance_turn")
@@ -620,7 +624,7 @@ func _highlight_valid_placements(domino) -> void:
 	_clear_next_slot_indicators()
 	var path_names := ["Path1", "Path2", "Path3", "Path4", "Path5", "Path6", "SunrisePath", "SunsetPath"]
 	for i in range(path_names.size()):
-		var path_node = get_node_or_null(path_names[i])
+		var path_node = get_node_or_null("WorldElements/" + path_names[i])
 		if path_node and path_node.has_method("set_placement_indicator"):
 			path_node.rotation = deg_to_rad(PATH_ANGLE_DEGREES[i] + ROTATION_OFFSET_DEG)
 			# Check if this domino can be placed on this path
@@ -649,7 +653,7 @@ func _highlight_valid_placements(domino) -> void:
 func _clear_placement_indicators() -> void:
 	var path_names := ["Path1", "Path2", "Path3", "Path4", "Path5", "Path6", "SunrisePath", "SunsetPath"]
 	for path_name in path_names:
-		var path_node = get_node_or_null(path_name)
+		var path_node = get_node_or_null("WorldElements/" + path_name)
 		if path_node and path_node.has_method("clear_indicators"):
 			path_node.clear_indicators()
 	_clear_next_slot_indicators()
@@ -689,7 +693,7 @@ func _update_train_indicator(path_num: int, is_open: bool) -> void:
 	var path_names := ["Path1", "Path2", "Path3", "Path4", "Path5", "Path6", "SunrisePath", "SunsetPath"]
 	if path_num < 0 or path_num >= path_names.size():
 		return
-	var path_node = get_node_or_null(path_names[path_num])
+	var path_node = get_node_or_null("WorldElements/" + path_names[path_num])
 	if path_node and path_node.has_method("set_train_indicator"):
 		path_node.rotation = deg_to_rad(PATH_ANGLE_DEGREES[path_num] + ROTATION_OFFSET_DEG)
 		# Pass category color for train indicator
@@ -702,23 +706,23 @@ func _update_train_indicator(path_num: int, is_open: bool) -> void:
 
 # increment total score for player
 func increment_total(num):
-	var path = "Character Bubble" + str(num) + "/Score/Button/Popup/Lydia_number"
+	var path = "WorldElements/Character Bubble" + str(num) + "/Score/Button/Popup/Lydia_number"
 	get_node(path).text = str(int(get_node(path).text) + 1)
 	gamestate.lydia_lion[num] = int(get_node(path).text)
-	$Acquire.playing = true
+	acquire_sound.playing = true
 
 
 # display wellness bead popup
 func display_wellness_prompt():
-	$WellnessBeadPopup/Title.text = "You Got a..."
-	$WellnessBeadPopup/WellnessBead.text = "Wellness Bead!"
-	$WellnessBeadPopup/Info.text = "You helped someone on their path and so helped promote community wellness!"
-	$WellnessBeadPopup.visible = true
+	$UIElements/WellnessBeadPopup/Title.text = "You Got a..."
+	$UIElements/WellnessBeadPopup/WellnessBead.text = "Wellness Bead!"
+	$UIElements/WellnessBeadPopup/Info.text = "You helped someone on their path and so helped promote community wellness!"
+	$UIElements/WellnessBeadPopup.visible = true
 
 
 # increment wellness beads for player denoted by num
 @rpc("any_peer") func increment_wellness_beads(num):
-	var path = "Character Bubble" + str(num) + "/Score/Button/Popup/Wellness_number"
+	var path = "WorldElements/Character Bubble" + str(num) + "/Score/Button/Popup/Wellness_number"
 	get_node(path).text = str(int(get_node(path).text) + 1)
 	gamestate.wellness_beads[num] = get_node(path).text
 	increment_total(num)
@@ -726,20 +730,20 @@ func display_wellness_prompt():
 
 # increment alloys earned for player denoted by num
 @rpc("any_peer") func increment_alloys(num, alloy):
-	var path = "Character Bubble" + str(num) + "/Score/Button/Popup/Alloy_number"
+	var path = "WorldElements/Character Bubble" + str(num) + "/Score/Button/Popup/Alloy_number"
 	get_node(path).text = str(int(get_node(path).text) + 1)
 	gamestate.alloys[num] = int(get_node(path).text)
 	increment_total(num)
 	
-	$AlloyPopup/Title.text = "Alloy Acquired!"
-	$AlloyPopup/Alloy.text = alloy
-	$AlloyPopup/Info.text = curriculum.alloy_table[alloy]
-	$AlloyPopup.visible = true
+	$UIElements/AlloyPopup/Title.text = "Alloy Acquired!"
+	$UIElements/AlloyPopup/Alloy.text = alloy
+	$UIElements/AlloyPopup/Info.text = curriculum.alloy_table[alloy]
+	$UIElements/AlloyPopup.visible = true
 
 
 # increment footprint tiles earned for player denoted by player_num
 @rpc("any_peer") func increment_footprint_tiles(player_num, round_num, footprint_num):
-	var path = "Character Bubble" + str(player_num) + "/Score/Button/Popup/Footprint_number"
+	var path = "WorldElements/Character Bubble" + str(player_num) + "/Score/Button/Popup/Footprint_number"
 	get_node(path).text = str(int(get_node(path).text) + 1)
 	gamestate.footprint_tiles[player_num] = int(get_node(path).text)
 	increment_total(player_num)
@@ -750,19 +754,19 @@ func display_wellness_prompt():
 func display_footprint_tile(round_num: int, footprint_num: int) -> void:
 	var index = FootprintTile.convert_to_index(footprint_num, round_num)
 	if round_num < 6:
-		$FootprintTilePopup/Title.text = "Footprint Tile Acquired!"
+		$UIElements/FootprintTilePopup/Title.text = "Footprint Tile Acquired!"
 		# TODO: <remove the else block and refactor once all 60 footprint tiles have been reimplemented in curriculum.footprint_tile_table>
 		if index < 30: # if one of the tiles reimplemented in footprint_tile_table (the first 30 so far)
 			# use the new implementation
-			$FootprintTilePopup/FootprintTile.text = curriculum.footprint_tile_table[index][0]
-			$FootprintTilePopup/Info.text = ""
-			$FootprintTilePopup/Description.text = curriculum.footprint_tile_table[index][1]
+			$UIElements/FootprintTilePopup/FootprintTile.text = curriculum.footprint_tile_table[index][0]
+			$UIElements/FootprintTilePopup/Info.text = ""
+			$UIElements/FootprintTilePopup/Description.text = curriculum.footprint_tile_table[index][1]
 		else: # otherwise use the old implementation
 			var table_index = str(round_num) + str(footprint_num)
-			$FootprintTilePopup/FootprintTile.text = curriculum.footprint_title_table[table_index]
-			$FootprintTilePopup/Info.text = curriculum.footprint_text_table[table_index]
-			$FootprintTilePopup/Description.text = ""
-		$FootprintTilePopup.visible = true
+			$UIElements/FootprintTilePopup/FootprintTile.text = curriculum.footprint_title_table[table_index]
+			$UIElements/FootprintTilePopup/Info.text = curriculum.footprint_text_table[table_index]
+			$UIElements/FootprintTilePopup/Description.text = ""
+		$UIElements/FootprintTilePopup.visible = true
 
 # update domino path for all players after a player places a domino
 @rpc("any_peer") func update_domino_path(domino_nums, domino_elms, pos, path_num, flip):
@@ -833,49 +837,31 @@ func replace_domino():
 	# if we've completed round 9, end game
 	if center_num >= 9:
 		add_tower(center_num + 1)
-		$Turn.text = "Game\nOver!"
-		$End.text = "Winner: " + determine_winner() + "\n(Hover over faces to see stats.)"
-		$End.visible = true
-		$Next.visible = false
-		# (Fall 2025) added visibility conditions for created buttons
-		$Help.visible = false
-		
-		# Only show the reset button to the host
+		turn_label.text = "Game\nOver!"
+		end_label.text = "Winner: " + determine_winner() + "\n(Hover over faces to see stats.)"
+		end_label.visible = true
+		next_button.visible = false
+		help_button.visible = false
 		if multiplayer.is_server():
-			$Reset.visible = true
+			reset_button.visible = true
 		else:
-			$Reset.visible = false
-
+			reset_button.visible = false
 		center_num += 1
 		return
-
-	# randomize dominos
 	dominos = [] + gamestate.dominos
 	dominos.shuffle()
-
-	# increment round number
 	center_num += 1
-
 	SaveManager.Save["0"].Current_Round += 1
-
-	# add tower
 	add_tower(center_num)
-	
-	# remove center domino from deck
 	print(center_num, center_num)
 	dominos.erase([center_num, center_num])
-
-	# reset domino paths
 	path_ends = []
 	for _i in range(8):
 		path_ends.append(center_num)
 	end_dominos = [null, null, null, null, null, null, null, null]
-
-	# load center domino
 	var domino_title = ReferenceManager.get_reference("dominos/" + str(center_num) + str(center_num) + ".png")
-	$CentralDomino.get_node("Sprite2D").texture = load(domino_title)
-	
-	var center_area := $CentralDomino.get_node_or_null("Area2D")
+	central_domino.get_node("Sprite2D").texture = load(domino_title)
+	var center_area := central_domino.get_node_or_null("Area2D")
 	if center_area:
 		center_area.input_pickable = false
 		center_area.monitoring = false
@@ -883,7 +869,7 @@ func replace_domino():
 	# reset path visibility
 	for i in range(1, 7):
 		if i != self_num + 1:
-			var path_node = get_node("Path" + str(i))
+			var path_node = get_node("WorldElements/Path" + str(i))
 			if path_node:
 				path_node.visible = true
 				print("Found and made visible: Path" + str(i))
@@ -944,9 +930,9 @@ func _update_turn_label():
 	var current_player_id = sorted_players[turn]
 	var current_name = gamestate.players[current_player_id]
 	
-	$Turn.text = current_name + "'s\nTurn"
+	turn_label.text = current_name + "'s\nTurn"
 	# Only show the "Need Help" button if it is currently YOUR turn
-	$Help.visible = (turn == self_num)
+	help_button.visible = (turn == self_num)
 	
 	# CPU TURN AUTOMATION (HOST ONLY)
 	if str(current_name).contains("CPU") and multiplayer.is_server():
@@ -1004,7 +990,7 @@ func _execute_cpu_turn_async(cpu_id):
 		update_domino_path([true_bot, true_top], [bot_e, top_e], position_table[move.path_idx], move.path_idx, flip)
 		
 		# POPUP PAUSE LOGIC
-		while $AlloyPopup.visible or $FootprintTilePopup.visible or $WellnessBeadPopup.visible:
+		while $UIElements/AlloyPopup.visible or $UIElements/FootprintTilePopup.visible or $UIElements/WellnessBeadPopup.visible:
 			await get_tree().process_frame
 		
 		if true_top == true_bot:
@@ -1023,7 +1009,7 @@ func _on_Next_pressed() -> void:
 	# reset field for host
 	next_round()
 	can_place = true
-	$Help.visible = false
+	help_button.visible = false
 
 	# reset field for everyone else
 	for p in gamestate.players:
@@ -1045,40 +1031,40 @@ func _on_Reset_pressed() -> void:
 
 #intialize tower as not seen
 func intialize_tower():
-	$Tower/Sprite2D/Energy.visible = false
-	$Tower/Sprite2D/Stability.visible = false
-	$Tower/Sprite2D/Prepared_Enviroment.visible = false
-	$Tower/Sprite2D/Ability.visible = false
-	$Tower/Sprite2D/Responsibility.visible = false
-	$Tower/Sprite2D/Perception.visible = false
-	$Tower/Sprite2D/Resilience.visible = false
-	$Tower/Sprite2D/Relationship.visible = false
-	$Tower/Sprite2D/Discernment.visible = false
-	$Tower/Sprite2D/Arts.visible = false
-	$Tower/Sprite2D/Sciences.visible = false
-	$Tower/Sprite2D/Humanities.visible = false
-	$Tower/Sprite2D/Diamond.visible = false
+	$WorldElements/Tower/Sprite2D/Energy.visible = false
+	$WorldElements/Tower/Sprite2D/Stability.visible = false
+	$WorldElements/Tower/Sprite2D/Prepared_Enviroment.visible = false
+	$WorldElements/Tower/Sprite2D/Ability.visible = false
+	$WorldElements/Tower/Sprite2D/Responsibility.visible = false
+	$WorldElements/Tower/Sprite2D/Perception.visible = false
+	$WorldElements/Tower/Sprite2D/Resilience.visible = false
+	$WorldElements/Tower/Sprite2D/Relationship.visible = false
+	$WorldElements/Tower/Sprite2D/Discernment.visible = false
+	$WorldElements/Tower/Sprite2D/Arts.visible = false
+	$WorldElements/Tower/Sprite2D/Sciences.visible = false
+	$WorldElements/Tower/Sprite2D/Humanities.visible = false
+	$WorldElements/Tower/Sprite2D/Diamond.visible = false
 
 # Display tower
 func add_tower(round_num):
 	if round_num == 6:
-		$Tower/Sprite2D/Energy.visible = true
-		$Tower/Sprite2D/Stability.visible = true
-		$Tower/Sprite2D/Prepared_Enviroment.visible = true
+		$WorldElements/Tower/Sprite2D/Energy.visible = true
+		$WorldElements/Tower/Sprite2D/Stability.visible = true
+		$WorldElements/Tower/Sprite2D/Prepared_Enviroment.visible = true
 	elif round_num == 7:
-		$Tower/Sprite2D/Ability.visible = true
-		$Tower/Sprite2D/Responsibility.visible = true
-		$Tower/Sprite2D/Perception.visible = true
+		$WorldElements/Tower/Sprite2D/Ability.visible = true
+		$WorldElements/Tower/Sprite2D/Responsibility.visible = true
+		$WorldElements/Tower/Sprite2D/Perception.visible = true
 	elif round_num == 8:
-		$Tower/Sprite2D/Resilience.visible = true
-		$Tower/Sprite2D/Relationship.visible = true
-		$Tower/Sprite2D/Discernment.visible = true
+		$WorldElements/Tower/Sprite2D/Resilience.visible = true
+		$WorldElements/Tower/Sprite2D/Relationship.visible = true
+		$WorldElements/Tower/Sprite2D/Discernment.visible = true
 	elif round_num == 9:
-		$Tower/Sprite2D/Arts.visible = true
-		$Tower/Sprite2D/Sciences.visible = true
-		$Tower/Sprite2D/Humanities.visible = true
+		$WorldElements/Tower/Sprite2D/Arts.visible = true
+		$WorldElements/Tower/Sprite2D/Sciences.visible = true
+		$WorldElements/Tower/Sprite2D/Humanities.visible = true
 	elif round_num == 10:
-		$Tower/Sprite2D/Diamond.visible = true
+		$WorldElements/Tower/Sprite2D/Diamond.visible = true
 
 func _on_Help_pressed() -> void:
 	if turn == self_num:
@@ -1089,35 +1075,35 @@ func _on_Help_pressed() -> void:
 		SFXController.playSFX(ReferenceManager.get_reference("next.wav"))
 
 @rpc("any_peer") func add_path(num):
-	var path_node = get_node_or_null("Path" + str(num))
+	var path_node = get_node_or_null("WorldElements/Path" + str(num))
 	if path_node:
 		path_node.visible = true
 
 @rpc("any_peer") func remove_path(num):
-	var path_node = get_node_or_null("Path" + str(num))
+	var path_node = get_node_or_null("WorldElements/Path" + str(num))
 	if path_node and "temp" in path_node and path_node.temp:
 		path_node.visible = false
 
 func _close_WellnessBead_popup() -> void:
-	$WellnessBeadPopup.visible = false
+	$UIElements/WellnessBeadPopup.visible = false
 
 func _close_Alloy_popup() -> void:
-	$AlloyPopup.visible = false
+	$UIElements/AlloyPopup.visible = false
 
 func _close_FootprintTile_popup():
-	$FootprintTilePopup.visible = false
+	$UIElements/FootprintTilePopup.visible = false
 	
 # return winner's name (could also be names depending on ties) based on highest total points
 func determine_winner():
 	var best_score = -1
 	var winners = []
 	for i in range(1, len(sorted_players) + 1):
-		var current_player = get_node("Character Bubble" + str(i) + "/Score/Button/Popup")
-		if int(current_player.get_node("Lydia_number").text) > best_score:
-			winners = [current_player.get_node("Name_text").text]
-			best_score = int(current_player.get_node("Lydia_number").text)
-		elif int(current_player.get_node("Lydia_number").text) == best_score:
-			winners.append(current_player.get_node("Name_text").text)
+		var current_player = get_node("WorldElements/Character Bubble" + str(i) + "/Score/Button/Popup")
+		if int(current_player.get_node("WorldElements/Lydia_number").text) > best_score:
+			winners = [current_player.get_node("WorldElements/Name_text").text]
+			best_score = int(current_player.get_node("WorldElements/Lydia_number").text)
+		elif int(current_player.get_node("WorldElements/Lydia_number").text) == best_score:
+			winners.append(current_player.get_node("WorldElements/Name_text").text)
 	var winner_text = ""
 	for winner in winners:
 		winner_text += winner
@@ -1127,97 +1113,104 @@ func determine_winner():
 	return winner_text
 
 func _on_Code_pressed():
-	$EnterCodeMenu.visible = true
-	$EnterCodeMenu/InvalidCode.visible = false
-	$EnterCodeMenu/UsedCode.visible = false
-	$EnterCodeMenu/AcceptCode.visible = false
+	$WorldElements/EnterCodeMenu.visible = true
+	$WorldElements/EnterCodeMenu/InvalidCode.visible = false
+	$WorldElements/EnterCodeMenu/UsedCode.visible = false
+	$WorldElements/EnterCodeMenu/AcceptCode.visible = false
 	SFXController.playSFX(ReferenceManager.get_reference("next.wav"))
 
 func _on_X_pressed():
-	$EnterCodeMenu.visible = false
-	$EnterCodeMenu/InvalidCode.visible = false
-	$EnterCodeMenu/UsedCode.visible = false
-	$EnterCodeMenu/AcceptCode.visible = false
+	$WorldElements/EnterCodeMenu.visible = false
+	$WorldElements/EnterCodeMenu/InvalidCode.visible = false
+	$WorldElements/EnterCodeMenu/UsedCode.visible = false
+	$WorldElements/EnterCodeMenu/AcceptCode.visible = false
 	SFXController.playSFX(ReferenceManager.get_reference("back.wav"))
 
 func _on_EnterButton_pressed():
 	var i = 0
 	var wrongFlag = true
-	$EnterCodeMenu/InvalidCode.visible = false
-	$EnterCodeMenu/UsedCode.visible = false
-	$EnterCodeMenu/AcceptCode.visible = false
-	#print($CodeEnterParent/TextEdit.text)
+	$WorldElements/EnterCodeMenu/InvalidCode.visible = false
+	$WorldElements/EnterCodeMenu/UsedCode.visible = false
+	$WorldElements/EnterCodeMenu/AcceptCode.visible = false
 	for word in usedBonus:
-		if ($EnterCodeMenu/MarginContainer/VBoxContainer/NinePatchRect/MarginContainer/LineEdit.text == word):
-			$EnterCodeMenu/UsedCode.visible = true
+		if ($WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer/NinePatchRect/MarginContainer/LineEdit.text == word):
+			$WorldElements/EnterCodeMenu/UsedCode.visible = true
 			wrongFlag = false
 	for word in bonusWords:
-		if ($EnterCodeMenu/MarginContainer/VBoxContainer/NinePatchRect/MarginContainer/LineEdit.text == word):
-			$EnterCodeMenu/AcceptCode.visible = true
+		if ($WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer/NinePatchRect/MarginContainer/LineEdit.text == word):
+			$WorldElements/EnterCodeMenu/AcceptCode.visible = true
 			increment_total(self_num + 1)
 			bonusWords.remove(i)
 			usedBonus.append(word)
 			wrongFlag = false
 		i = i + 1
 	if (wrongFlag == true):
-		$EnterCodeMenu/InvalidCode.visible = true
+		$WorldElements/EnterCodeMenu/InvalidCode.visible = true
 		SFXController.playSFX(ReferenceManager.get_reference("back.wav"))
 
-# Updated button UI
-# 4/18/2024
+
 var green = Color("74cc4c")
 var grey = Color("aaaaaa")
 
-#### VVVV BUTTON HOVER HANDLERS VVVV ####
-
-# Set label color to green when mouse enters texture button.
-# Set label color back to grey when mouse leaves.
 
 func _on_EnterCode_mouse_entered():
-	$Code/MarginContainer/Label.set("theme_override_colors/font_color", green)
+	$WorldElements/Code/MarginContainer/Label.set("theme_override_colors/font_color", green)
+
+
 func _on_EnterCode_mouse_exited():
-	$Code/MarginContainer/Label.set("theme_override_colors/font_color", grey)
+	$WorldElements/Code/MarginContainer/Label.set("theme_override_colors/font_color", grey)
+
 
 func _on_Next_mouse_entered():
-	$Next/MarginContainer/Label.set("theme_override_colors/font_color", green)
+	$WorldElements/Next/MarginContainer/Label.set("theme_override_colors/font_color", green)
+
+
 func _on_Next_mouse_exited():
-	$Next/MarginContainer/Label.set("theme_override_colors/font_color", grey)
+	$WorldElements/Next/MarginContainer/Label.set("theme_override_colors/font_color", grey)
+
 
 func _on_Help_mouse_entered():
-	$Help/MarginContainer/Label.set("theme_override_colors/font_color", green)
+	$WorldElements/Help/MarginContainer/Label.set("theme_override_colors/font_color", green)
+
+
 func _on_Help_mouse_exited():
-	$Help/MarginContainer/Label.set("theme_override_colors/font_color", grey)
-	
+	$WorldElements/Help/MarginContainer/Label.set("theme_override_colors/font_color", grey)
+
+
 func _on_Reset_mouse_entered():
-	$Reset/MarginContainer/Label.set("theme_override_colors/font_color", green)
+	$WorldElements/Reset/MarginContainer/Label.set("theme_override_colors/font_color", green)
+
+
 func _on_Reset_mouse_exited():
-	$Reset/MarginContainer/Label.set("theme_override_colors/font_color", grey)
+	$WorldElements/Reset/MarginContainer/Label.set("theme_override_colors/font_color", grey)
+
 
 func _on_Start_mouse_entered():
-	$Start/MarginContainer/Label.set("theme_override_colors/font_color", green)
+	$WorldElements/Start/MarginContainer/Label.set("theme_override_colors/font_color", green)
+
+
 func _on_Start_mouse_exited():
-	$Start/MarginContainer/Label.set("theme_override_colors/font_color", grey)
-	
-#### ^^^^ END BUTTON HOVER HANDLERS ^^^^ ####
+	$WorldElements/Start/MarginContainer/Label.set("theme_override_colors/font_color", grey)
 
 
 func _on_HelpButton_pressed():
-	$HelpMenu/HelpImage.visible = true
-	$HelpMenu.move_to_front()
+	$WorldElements/HelpMenu/HelpImage.visible = true
+	$WorldElements/HelpMenu.move_to_front()
+
 
 func _on_CloseButton_pressed():
-	$HelpMenu/HelpImage.visible = false
-	
-	
-# functions to fix domino alignment 10/1/2025
+	$WorldElements/HelpMenu/HelpImage.visible = false
+
 
 func _deg_to_vec2(angle_deg: float) -> Vector2:
 	var a := deg_to_rad(angle_deg)
 	return Vector2(cos(a), sin(a))
 
+
 func _path_step_vector(path_num: int) -> Vector2:
 	var v := _deg_to_vec2(PATH_ANGLE_DEGREES[path_num])
 	return v * STEP_PIXELS
+
 
 func _path_position_for_step(path_num: int, step_index: int) -> Vector2:
 	# Treat stored anchors as LOCAL positions in this DominoWorld
@@ -1232,9 +1225,11 @@ func _path_position_for_step(path_num: int, step_index: int) -> Vector2:
 func _orient_to_path(domino: Node2D, path_num: int) -> void:
 	domino.rotation = deg_to_rad(PATH_ANGLE_DEGREES[path_num] + ROTATION_OFFSET_DEG)
 
+
 func _verify_anchors_ready():
 	if position_table.size() != 8:
 		push_error("Expected 8 anchors, have %s" % position_table.size())
+
 
 func set_anchor(path_index: int, global_pos: Vector2) -> void:
 	if path_index < 0 or path_index >= position_table.size():

--- a/Scenes/Level_4_DominoWorld/DominoWorld.tscn
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.tscn
@@ -29,143 +29,6 @@
 [ext_resource type="Texture2D" uid="uid://cgb7uykpyjide" path="res://UI/sprites/close.png" id="28"]
 [ext_resource type="PackedScene" uid="uid://onq3cam2n0us" path="res://Scenes/Core/PauseMenu.tscn" id="29_bru2g"]
 
-[sub_resource type="Animation" id="1"]
-resource_name = "Zoom In"
-length = 0.2
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("Camera2D:zoom")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.2),
-"transitions": PackedFloat32Array(1, 1),
-"update": 0,
-"values": [Vector2(2.5, 2.5), Vector2(1.7, 1.7)]
-}
-
-[sub_resource type="Animation" id="2"]
-length = 0.2
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("Camera2D:zoom")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.2),
-"transitions": PackedFloat32Array(1, 1),
-"update": 0,
-"values": [Vector2(1.7, 1.7), Vector2(2.5, 2.5)]
-}
-
-[sub_resource type="AnimationLibrary" id="AnimationLibrary_vh554"]
-_data = {
-&"Zoom In": SubResource("1"),
-&"Zoom Out": SubResource("2")
-}
-
-[sub_resource type="FontFile" id="5"]
-fallbacks = Array[Font]([ExtResource("10"), ExtResource("10")])
-subpixel_positioning = 0
-msdf_pixel_range = 14
-msdf_size = 128
-cache/0/variation_coordinates = {}
-cache/0/face_index = 0
-cache/0/embolden = 0.0
-cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
-cache/0/spacing_top = 0
-cache/0/spacing_bottom = 0
-cache/0/spacing_space = 0
-cache/0/spacing_glyph = 0
-cache/0/baseline_offset = 0.0
-cache/0/16/0/ascent = 0.0
-cache/0/16/0/descent = 0.0
-cache/0/16/0/underline_position = 0.0
-cache/0/16/0/underline_thickness = 0.0
-cache/0/16/0/scale = 1.0
-
-[sub_resource type="FontFile" id="6"]
-fallbacks = Array[Font]([ExtResource("10"), ExtResource("10")])
-subpixel_positioning = 0
-msdf_pixel_range = 14
-msdf_size = 128
-cache/0/variation_coordinates = {}
-cache/0/face_index = 0
-cache/0/embolden = 0.0
-cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
-cache/0/spacing_top = 0
-cache/0/spacing_bottom = 0
-cache/0/spacing_space = 0
-cache/0/spacing_glyph = 0
-cache/0/baseline_offset = 0.0
-cache/0/16/0/ascent = 0.0
-cache/0/16/0/descent = 0.0
-cache/0/16/0/underline_position = 0.0
-cache/0/16/0/underline_thickness = 0.0
-cache/0/16/0/scale = 1.0
-
-[sub_resource type="FontFile" id="7"]
-fallbacks = Array[Font]([ExtResource("10"), ExtResource("10")])
-subpixel_positioning = 0
-msdf_pixel_range = 14
-msdf_size = 128
-cache/0/variation_coordinates = {}
-cache/0/face_index = 0
-cache/0/embolden = 0.0
-cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
-cache/0/spacing_top = 0
-cache/0/spacing_bottom = 0
-cache/0/spacing_space = 0
-cache/0/spacing_glyph = 0
-cache/0/baseline_offset = 0.0
-cache/0/16/0/ascent = 0.0
-cache/0/16/0/descent = 0.0
-cache/0/16/0/underline_position = 0.0
-cache/0/16/0/underline_thickness = 0.0
-cache/0/16/0/scale = 1.0
-
-[sub_resource type="FontFile" id="8"]
-fallbacks = Array[Font]([ExtResource("10"), ExtResource("10")])
-subpixel_positioning = 0
-msdf_pixel_range = 14
-msdf_size = 128
-cache/0/variation_coordinates = {}
-cache/0/face_index = 0
-cache/0/embolden = 0.0
-cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
-cache/0/spacing_top = 0
-cache/0/spacing_bottom = 0
-cache/0/spacing_space = 0
-cache/0/spacing_glyph = 0
-cache/0/baseline_offset = 0.0
-cache/0/16/0/ascent = 0.0
-cache/0/16/0/descent = 0.0
-cache/0/16/0/underline_position = 0.0
-cache/0/16/0/underline_thickness = 0.0
-cache/0/16/0/scale = 1.0
-
-[sub_resource type="FontFile" id="10"]
-fallbacks = Array[Font]([ExtResource("10"), ExtResource("10")])
-subpixel_positioning = 0
-msdf_pixel_range = 14
-msdf_size = 128
-cache/0/variation_coordinates = {}
-cache/0/face_index = 0
-cache/0/embolden = 0.0
-cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
-cache/0/spacing_top = 0
-cache/0/spacing_bottom = 0
-cache/0/spacing_space = 0
-cache/0/spacing_glyph = 0
-cache/0/baseline_offset = 0.0
-cache/0/16/0/ascent = 0.0
-cache/0/16/0/descent = 0.0
-cache/0/16/0/underline_position = 0.0
-cache/0/16/0/underline_thickness = 0.0
-cache/0/16/0/scale = 1.0
-
 [sub_resource type="FontFile" id="11"]
 fallbacks = Array[Font]([ExtResource("16"), ExtResource("16")])
 subpixel_positioning = 0
@@ -290,22 +153,503 @@ region_rect = Rect2(0, 0, 512, 512)
 texture = ExtResource("28")
 region_rect = Rect2(0, 0, 512, 512)
 
+[sub_resource type="FontFile" id="5"]
+fallbacks = Array[Font]([ExtResource("10"), ExtResource("10")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+
+[sub_resource type="FontFile" id="6"]
+fallbacks = Array[Font]([ExtResource("10"), ExtResource("10")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+
+[sub_resource type="FontFile" id="7"]
+fallbacks = Array[Font]([ExtResource("10"), ExtResource("10")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+
+[sub_resource type="FontFile" id="8"]
+fallbacks = Array[Font]([ExtResource("10"), ExtResource("10")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+
+[sub_resource type="FontFile" id="10"]
+fallbacks = Array[Font]([ExtResource("10"), ExtResource("10")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+
+[sub_resource type="Animation" id="1"]
+resource_name = "Zoom In"
+length = 0.2
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("WorldElements/Camera2D:zoom")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(2.5, 2.5), Vector2(1.7, 1.7)]
+}
+
+[sub_resource type="Animation" id="2"]
+length = 0.2
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("WorldElements/Camera2D:zoom")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(1.7, 1.7), Vector2(2.5, 2.5)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_vh554"]
+_data = {
+&"Zoom In": SubResource("1"),
+&"Zoom Out": SubResource("2")
+}
+
 [node name="World" type="Node2D" unique_id=1181802440]
 scale = Vector2(0.5, 0.5)
 script = ExtResource("7")
 Domino = ExtResource("8")
 
-[node name="PauseCL" type="CanvasLayer" parent="." unique_id=5341854]
-layer = 15
+[node name="WorldElements" type="Node2D" parent="." unique_id=1641153460]
 
-[node name="PauseMenu" parent="PauseCL" unique_id=2053464100 instance=ExtResource("29_bru2g")]
-visible = false
-
-[node name="Camera2D" type="Camera2D" parent="." unique_id=1077432123]
-position = Vector2(-192, 0)
+[node name="Camera2D" type="Camera2D" parent="WorldElements" unique_id=1077432123]
+position = Vector2(-191.99998, -1.5258789e-05)
+scale = Vector2(0.99999994, 0.99999994)
 zoom = Vector2(2.5, 2.5)
+drag_horizontal_enabled = true
+drag_vertical_enabled = true
 
-[node name="Board" type="Sprite2D" parent="." unique_id=496976469]
+[node name="SaveButton" parent="WorldElements" unique_id=1717313087 instance=ExtResource("14")]
+visible = false
+position = Vector2(-186, -222)
+scale = Vector2(0.4, 0.4)
+
+[node name="Start" type="TextureButton" parent="WorldElements" unique_id=1164943152]
+offset_left = -228.0
+offset_top = 132.0
+offset_right = -38.0
+offset_bottom = 181.0
+scale = Vector2(0.4, 0.4)
+mouse_default_cursor_shape = 2
+texture_normal = ExtResource("19")
+texture_pressed = ExtResource("18")
+texture_hover = ExtResource("20")
+
+[node name="MarginContainer" type="MarginContainer" parent="WorldElements/Start" unique_id=1138882031]
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+theme_override_constants/margin_bottom = 15
+
+[node name="Label" type="Label" parent="WorldElements/Start/MarginContainer" unique_id=2113117972]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_colors/font_color = Color(0.666667, 0.666667, 0.666667, 1)
+theme_override_fonts/font = SubResource("11")
+text = "Start"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Reset" type="TextureButton" parent="WorldElements" unique_id=1091096365]
+offset_left = -228.0
+offset_top = 156.0
+offset_right = -38.0
+offset_bottom = 205.0
+scale = Vector2(0.4, 0.4)
+mouse_default_cursor_shape = 2
+texture_normal = ExtResource("19")
+texture_pressed = ExtResource("18")
+texture_hover = ExtResource("20")
+
+[node name="MarginContainer" type="MarginContainer" parent="WorldElements/Reset" unique_id=1372665780]
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+theme_override_constants/margin_bottom = 15
+
+[node name="Label" type="Label" parent="WorldElements/Reset/MarginContainer" unique_id=1863938518]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_colors/font_color = Color(0.666667, 0.666667, 0.666667, 1)
+theme_override_fonts/font = SubResource("11")
+text = "Reset"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Code" type="TextureButton" parent="WorldElements" unique_id=51973216]
+visible = false
+offset_left = -154.0
+offset_top = -228.0
+offset_right = 36.0
+offset_bottom = -179.0
+scale = Vector2(0.4, 0.4)
+mouse_default_cursor_shape = 2
+texture_normal = ExtResource("19")
+texture_pressed = ExtResource("18")
+texture_hover = ExtResource("20")
+metadata/_edit_use_anchors_ = true
+
+[node name="MarginContainer" type="MarginContainer" parent="WorldElements/Code" unique_id=1256968813]
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+theme_override_constants/margin_bottom = 15
+
+[node name="Label" type="Label" parent="WorldElements/Code/MarginContainer" unique_id=1068016564]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
+theme_override_fonts/font = SubResource("11")
+text = "Enter Code"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Next" type="TextureButton" parent="WorldElements" unique_id=750766444]
+offset_left = -144.0
+offset_top = -232.0
+offset_right = 46.0
+offset_bottom = -183.0
+scale = Vector2(0.4, 0.4)
+mouse_default_cursor_shape = 2
+texture_normal = ExtResource("19")
+texture_pressed = ExtResource("18")
+texture_hover = ExtResource("20")
+
+[node name="MarginContainer" type="MarginContainer" parent="WorldElements/Next" unique_id=1524833728]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+theme_override_constants/margin_bottom = 15
+
+[node name="Label" type="Label" parent="WorldElements/Next/MarginContainer" unique_id=1133366593]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
+theme_override_fonts/font = SubResource("11")
+text = "Next Round"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Help" type="TextureButton" parent="WorldElements" unique_id=1604946150]
+offset_left = -372.0
+offset_top = 98.0
+offset_right = -182.0
+offset_bottom = 147.0
+scale = Vector2(0.4, 0.4)
+mouse_default_cursor_shape = 2
+texture_normal = ExtResource("19")
+texture_pressed = ExtResource("18")
+texture_hover = ExtResource("20")
+
+[node name="MarginContainer" type="MarginContainer" parent="WorldElements/Help" unique_id=753929215]
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+theme_override_constants/margin_bottom = 15
+
+[node name="Label" type="Label" parent="WorldElements/Help/MarginContainer" unique_id=417630671]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
+theme_override_fonts/font = SubResource("11")
+text = "Need Help"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="EnterCodeMenu" type="NinePatchRect" parent="WorldElements" unique_id=2094562660]
+visible = false
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -847.0
+offset_top = -495.0
+offset_right = 847.0
+offset_bottom = 495.0
+texture = ExtResource("25")
+region_rect = Rect2(0, 0, 100, 100)
+patch_margin_left = 31
+patch_margin_top = 28
+patch_margin_right = 29
+patch_margin_bottom = 28
+
+[node name="MarginContainer" type="MarginContainer" parent="WorldElements/EnterCodeMenu" unique_id=1367911909]
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+theme_override_constants/margin_left = 50
+theme_override_constants/margin_top = 100
+theme_override_constants/margin_right = 50
+theme_override_constants/margin_bottom = 100
+
+[node name="VBoxContainer" type="VBoxContainer" parent="WorldElements/EnterCodeMenu/MarginContainer" unique_id=819992936]
+layout_mode = 2
+theme_override_constants/separation = 25
+
+[node name="EnterCode" type="Label" parent="WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer" unique_id=1619657454]
+layout_mode = 2
+theme_override_fonts/font = SubResource("12")
+text = "Enter Code"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="NinePatchRect" type="NinePatchRect" parent="WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer" unique_id=1824846860]
+custom_minimum_size = Vector2(0, 150)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 0
+size_flags_stretch_ratio = 0.0
+texture = ExtResource("25")
+region_rect = Rect2(-1.09497, -1, 102.095, 102.423)
+patch_margin_left = 3
+patch_margin_top = 7
+patch_margin_right = 3
+patch_margin_bottom = 35
+
+[node name="MarginContainer" type="MarginContainer" parent="WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer/NinePatchRect" unique_id=1533910496]
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+theme_override_constants/margin_left = 25
+theme_override_constants/margin_right = 25
+
+[node name="LineEdit" type="LineEdit" parent="WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer/NinePatchRect/MarginContainer" unique_id=51159914]
+layout_mode = 2
+theme = ExtResource("17")
+theme_override_colors/font_color = Color(0.533333, 0.533333, 0.533333, 1)
+theme_override_fonts/font = SubResource("14")
+
+[node name="MarginContainer" type="MarginContainer" parent="WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer" unique_id=937920315]
+layout_mode = 2
+mouse_filter = 2
+theme_override_constants/margin_top = 150
+
+[node name="Enter" type="TextureButton" parent="WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer/MarginContainer" unique_id=1946840216]
+custom_minimum_size = Vector2(700, 200)
+layout_mode = 2
+size_flags_horizontal = 6
+mouse_default_cursor_shape = 2
+texture_normal = ExtResource("24")
+texture_pressed = ExtResource("23")
+texture_hover = ExtResource("23")
+
+[node name="MarginContainer" type="MarginContainer" parent="WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer/MarginContainer/Enter" unique_id=612261445]
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+theme_override_constants/margin_bottom = 25
+
+[node name="Label" type="Label" parent="WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer/MarginContainer/Enter/MarginContainer" unique_id=1386978179]
+layout_mode = 2
+theme = ExtResource("17")
+theme_override_fonts/font = SubResource("13")
+text = "Enter"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="X" type="TextureButton" parent="WorldElements/EnterCodeMenu" unique_id=187524548]
+layout_mode = 0
+offset_left = 1611.0
+offset_top = 25.0
+offset_right = 1665.0
+offset_bottom = 77.0
+mouse_default_cursor_shape = 2
+texture_normal = ExtResource("22")
+texture_pressed = ExtResource("21")
+texture_hover = ExtResource("21")
+
+[node name="InvalidCode" type="Label" parent="WorldElements/EnterCodeMenu" unique_id=1790883149]
+visible = false
+layout_mode = 0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_top = -42.0
+offset_bottom = 73.0
+theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
+theme_override_fonts/font = SubResource("15")
+text = "Invalid code!"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="UsedCode" type="Label" parent="WorldElements/EnterCodeMenu" unique_id=1267248247]
+visible = false
+layout_mode = 0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_top = -42.0
+offset_bottom = 73.0
+theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
+theme_override_fonts/font = SubResource("15")
+text = "This code has been used already!"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="AcceptCode" type="Label" parent="WorldElements/EnterCodeMenu" unique_id=405977017]
+visible = false
+layout_mode = 0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_top = -42.0
+offset_bottom = 73.0
+theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
+theme_override_fonts/font = SubResource("15")
+text = "Code accepted!"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="HelpMenu" type="Control" parent="WorldElements" unique_id=699493088]
+layout_mode = 3
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="HelpButton" type="Button" parent="WorldElements/HelpMenu" unique_id=95552350]
+texture_filter = 1
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 1.6
+anchor_top = 0.75
+anchor_right = 1.6
+anchor_bottom = 0.75
+offset_left = 53.0
+offset_top = -260.0
+offset_right = 255.0
+offset_bottom = -54.0
+scale = Vector2(0.15, 0.15)
+theme_override_styles/normal = SubResource("16")
+theme_override_styles/pressed = SubResource("20")
+theme_override_styles/hover = SubResource("18")
+icon_alignment = 1
+metadata/_edit_use_anchors_ = true
+
+[node name="HelpImage" type="TextureRect" parent="WorldElements/HelpMenu" unique_id=1678077797]
+visible = false
+layout_mode = 0
+offset_left = -506.0
+offset_top = -244.0
+offset_right = 6054.0
+offset_bottom = 4536.0
+scale = Vector2(0.1, 0.1)
+texture = ExtResource("26")
+metadata/_edit_lock_ = true
+
+[node name="CloseButton" type="Button" parent="WorldElements/HelpMenu/HelpImage" unique_id=899241210]
+layout_mode = 0
+offset_left = 6280.0
+offset_top = 80.0
+offset_right = 6444.0
+offset_bottom = 240.0
+theme_override_styles/normal = SubResource("17")
+theme_override_styles/pressed = SubResource("21")
+theme_override_styles/hover = SubResource("19")
+metadata/_edit_lock_ = true
+
+[node name="Board" type="Sprite2D" parent="WorldElements" unique_id=496976469]
 z_index = -3
 texture_filter = 1
 position = Vector2(-192, -50)
@@ -313,133 +657,126 @@ rotation = 1.20428
 scale = Vector2(0.3, 0.3)
 texture = ExtResource("1")
 
-[node name="Path1" parent="." unique_id=607809010 instance=ExtResource("9")]
+[node name="Path1" parent="WorldElements" unique_id=607809010 instance=ExtResource("9")]
 z_index = -2
 position = Vector2(-130, -176)
 scale = Vector2(0.03, 0.03)
 texture = null
 
-[node name="Path2" parent="." unique_id=853339331 instance=ExtResource("9")]
+[node name="Path2" parent="WorldElements" unique_id=853339331 instance=ExtResource("9")]
 z_index = -2
 position = Vector2(-318, -104.00002)
 scale = Vector2(0.03, 0.03)
 texture = null
 num = 1
 
-[node name="Path3" parent="." unique_id=1040527191 instance=ExtResource("9")]
+[node name="Path3" parent="WorldElements" unique_id=1040527191 instance=ExtResource("9")]
 z_index = -2
 position = Vector2(-58, -98)
 scale = Vector2(0.03, 0.03)
 texture = null
 num = 2
 
-[node name="Path4" parent="." unique_id=1591097373 instance=ExtResource("9")]
+[node name="Path4" parent="WorldElements" unique_id=1591097373 instance=ExtResource("9")]
 z_index = -2
 position = Vector2(-322, 6)
 scale = Vector2(0.03, 0.03)
 texture = null
 num = 3
 
-[node name="Path5" parent="." unique_id=550393547 instance=ExtResource("9")]
+[node name="Path5" parent="WorldElements" unique_id=550393547 instance=ExtResource("9")]
 z_index = -2
 position = Vector2(-246, 84)
 scale = Vector2(0.03, 0.03)
 texture = null
 num = 4
 
-[node name="Path6" parent="." unique_id=680097435 instance=ExtResource("9")]
+[node name="Path6" parent="WorldElements" unique_id=680097435 instance=ExtResource("9")]
 z_index = -2
 position = Vector2(-57.999992, 9.999996)
 scale = Vector2(0.03, 0.03)
 texture = null
 num = 5
 
-[node name="SunrisePath" parent="." unique_id=453627861 instance=ExtResource("9")]
+[node name="SunrisePath" parent="WorldElements" unique_id=453627861 instance=ExtResource("9")]
 z_index = -2
 position = Vector2(-240.00003, -180)
 scale = Vector2(0.03, 0.03)
 texture = null
 num = 6
 
-[node name="SunsetPath" parent="." unique_id=61258073 instance=ExtResource("9")]
+[node name="SunsetPath" parent="WorldElements" unique_id=61258073 instance=ExtResource("9")]
 z_index = -2
 position = Vector2(-139, 86.67999)
 scale = Vector2(0.03, 0.03)
 texture = null
 num = 7
 
-[node name="Character Bubble1" parent="." unique_id=1946415537 instance=ExtResource("3")]
+[node name="Character Bubble1" parent="WorldElements" unique_id=1946415537 instance=ExtResource("3")]
 z_index = -1
 position = Vector2(-114, -174)
 scale = Vector2(0.4, 0.4)
 
-[node name="face" parent="Character Bubble1" index="0" unique_id=707796254]
+[node name="face" parent="WorldElements/Character Bubble1" index="0" unique_id=707796254]
 position = Vector2(-60.9, 35)
 
-[node name="front_hair" parent="Character Bubble1" index="1" unique_id=633581683]
+[node name="front_hair" parent="WorldElements/Character Bubble1" index="1" unique_id=633581683]
 position = Vector2(-60.9, 130)
 
-[node name="back_hair" parent="Character Bubble1" index="2" unique_id=1771050701]
+[node name="back_hair" parent="WorldElements/Character Bubble1" index="2" unique_id=1771050701]
 position = Vector2(-60.9, 130)
 texture = ExtResource("13")
 
-[node name="Area2D" parent="Character Bubble1" index="3" unique_id=1953206665]
+[node name="Area2D" parent="WorldElements/Character Bubble1" index="3" unique_id=1953206665]
 position = Vector2(39.099995, -79.99999)
 
-[node name="CollisionShape2D" parent="Character Bubble1/Area2D" index="0" unique_id=1168569297]
+[node name="CollisionShape2D" parent="WorldElements/Character Bubble1/Area2D" index="0" unique_id=1168569297]
 position = Vector2(-100, 115)
 
-[node name="Score" parent="Character Bubble1" index="4" unique_id=1386002985]
+[node name="Score" parent="WorldElements/Character Bubble1" index="4" unique_id=1386002985]
 z_index = 2
 
-[node name="Popup" parent="Character Bubble1/Score/Button" index="2"]
-visible = false
-
-[node name="Character Bubble2" parent="." unique_id=917609711 instance=ExtResource("3")]
+[node name="Character Bubble2" parent="WorldElements" unique_id=917609711 instance=ExtResource("3")]
 z_index = -1
 position = Vector2(-302, -98.00001)
 scale = Vector2(0.4, 0.4)
 
-[node name="Character Bubble3" parent="." unique_id=892282258 instance=ExtResource("3")]
+[node name="Character Bubble3" parent="WorldElements" unique_id=892282258 instance=ExtResource("3")]
 z_index = -1
 position = Vector2(-72, -92)
 scale = Vector2(0.4, 0.4)
 
-[node name="Character Bubble4" parent="." unique_id=1105370240 instance=ExtResource("3")]
+[node name="Character Bubble4" parent="WorldElements" unique_id=1105370240 instance=ExtResource("3")]
 z_index = -1
 position = Vector2(-306, -9.536743e-07)
 scale = Vector2(0.4, 0.4)
 
-[node name="Character Bubble5" parent="." unique_id=1180595559 instance=ExtResource("3")]
+[node name="Character Bubble5" parent="WorldElements" unique_id=1180595559 instance=ExtResource("3")]
 z_index = -1
 position = Vector2(-240, 66)
 scale = Vector2(0.4, 0.4)
 
-[node name="Character Bubble6" parent="." unique_id=1836691644 instance=ExtResource("3")]
+[node name="Character Bubble6" parent="WorldElements" unique_id=1836691644 instance=ExtResource("3")]
 z_index = -1
 position = Vector2(-77.99999, -4.0000076)
 scale = Vector2(0.4, 0.4)
 
-[node name="sunrise" type="Sprite2D" parent="." unique_id=1731710693]
+[node name="sunrise" type="Sprite2D" parent="WorldElements" unique_id=1731710693]
 z_index = -1
 position = Vector2(-232, -166)
 scale = Vector2(0.25, 0.25)
 texture = ExtResource("4")
 
-[node name="sunset" type="Sprite2D" parent="." unique_id=338479446]
+[node name="sunset" type="Sprite2D" parent="WorldElements" unique_id=338479446]
 z_index = -1
 position = Vector2(-146, 66.00001)
 scale = Vector2(0.24, 0.24)
 texture = ExtResource("5")
 
-[node name="Settings" parent="." unique_id=1735084520 instance=ExtResource("6")]
-visible = false
-position = Vector2(-528, -304)
-
-[node name="CanvasLayer" type="CanvasLayer" parent="." unique_id=720694082]
+[node name="CanvasLayer" type="CanvasLayer" parent="WorldElements" unique_id=720694082]
 layer = -2
 
-[node name="ColorRect" type="ColorRect" parent="CanvasLayer" unique_id=704993846]
+[node name="ColorRect" type="ColorRect" parent="WorldElements/CanvasLayer" unique_id=704993846]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -454,19 +791,46 @@ mouse_filter = 2
 color = Color(0.21962506, 0.3584414, 0.36461106, 1)
 metadata/_edit_lock_ = true
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="." unique_id=369789060]
-libraries/ = SubResource("AnimationLibrary_vh554")
-autoplay = &"Zoom Out"
-
-[node name="Turn" type="Label" parent="." unique_id=479130248]
+[node name="CentralDomino" parent="WorldElements" unique_id=2035090892 instance=ExtResource("8")]
 texture_filter = 1
+position = Vector2(-192, 0)
+scale = Vector2(0.5, 0.5)
+placed = true
+
+[node name="Sprite2D" parent="WorldElements/CentralDomino" index="0" unique_id=1727582070]
+position = Vector2(8, -112)
+scale = Vector2(0.5, 0.5)
+
+[node name="CollisionShape2D" parent="WorldElements/CentralDomino/Area2D" parent_id_path=PackedInt32Array(2035090892, 1374037218) index="0" unique_id=923412705]
+position = Vector2(8, -112)
+scale = Vector2(0.8, 0.8)
+
+[node name="Tower" parent="WorldElements" unique_id=411159155 instance=ExtResource("15")]
+position = Vector2(-494, -86)
+scale = Vector2(0.2, 0.2)
+
+[node name="UIElements" type="Control" parent="." unique_id=109789685]
+layout_mode = 3
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="PauseCL" type="CanvasLayer" parent="UIElements" unique_id=5341854]
+layer = 15
+
+[node name="PauseMenu" parent="UIElements/PauseCL" unique_id=2053464100 instance=ExtResource("29_bru2g")]
+visible = false
+
+[node name="Turn" type="Label" parent="UIElements" unique_id=479130248]
+texture_filter = 1
+layout_mode = 0
 offset_top = -230.0
 offset_right = 140.0
 offset_bottom = -176.0
 theme_override_fonts/font = SubResource("5")
-metadata/_edit_use_anchors_ = true
 
-[node name="End" type="Label" parent="." unique_id=577962459]
+[node name="End" type="Label" parent="UIElements" unique_id=577962459]
+layout_mode = 0
 offset_left = 368.0
 offset_top = -664.0
 offset_right = 1256.0
@@ -479,11 +843,11 @@ faces to see
 scores)"
 horizontal_alignment = 1
 
-[node name="AlloyPopup" type="Popup" parent="." unique_id=1417684759]
+[node name="AlloyPopup" type="Popup" parent="UIElements" unique_id=1417684759]
 position = Vector2i(303, 75)
 size = Vector2i(417, 381)
 
-[node name="Title" type="Label" parent="AlloyPopup" unique_id=1207134264]
+[node name="Title" type="Label" parent="UIElements/AlloyPopup" unique_id=1207134264]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -499,7 +863,7 @@ text = "Alloy Acquired!"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Alloy" type="Label" parent="AlloyPopup" unique_id=401652230]
+[node name="Alloy" type="Label" parent="UIElements/AlloyPopup" unique_id=401652230]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -515,7 +879,7 @@ text = "Electrum"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Info" type="Label" parent="AlloyPopup" unique_id=2002101698]
+[node name="Info" type="Label" parent="UIElements/AlloyPopup" unique_id=2002101698]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -531,7 +895,7 @@ It represents ...
 "
 autowrap_mode = 3
 
-[node name="Close" type="Button" parent="AlloyPopup" unique_id=134790724]
+[node name="Close" type="Button" parent="UIElements/AlloyPopup" unique_id=134790724]
 anchors_preset = 7
 anchor_left = 0.5
 anchor_top = 1.0
@@ -546,11 +910,11 @@ grow_vertical = 0
 theme_override_fonts/font = SubResource("8")
 text = "OK"
 
-[node name="WellnessBeadPopup" type="Popup" parent="." unique_id=1268130132]
+[node name="WellnessBeadPopup" type="Popup" parent="UIElements" unique_id=1268130132]
 position = Vector2i(303, 75)
 size = Vector2i(417, 381)
 
-[node name="Title" type="Label" parent="WellnessBeadPopup" unique_id=1430087579]
+[node name="Title" type="Label" parent="UIElements/WellnessBeadPopup" unique_id=1430087579]
 anchors_preset = 5
 anchor_left = 0.5
 anchor_right = 0.5
@@ -564,7 +928,7 @@ text = "Alloy Acquired!"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="WellnessBead" type="Label" parent="WellnessBeadPopup" unique_id=750531192]
+[node name="WellnessBead" type="Label" parent="UIElements/WellnessBeadPopup" unique_id=750531192]
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
@@ -582,7 +946,7 @@ text = "Electrum"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Info" type="Label" parent="WellnessBeadPopup" unique_id=1770409782]
+[node name="Info" type="Label" parent="UIElements/WellnessBeadPopup" unique_id=1770409782]
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
@@ -598,7 +962,7 @@ theme_override_fonts/font = SubResource("7")
 text = "Electrum is an alloy of gold and silver.
 It represents ..."
 
-[node name="Close" type="Button" parent="WellnessBeadPopup" unique_id=402153372]
+[node name="Close" type="Button" parent="UIElements/WellnessBeadPopup" unique_id=402153372]
 anchors_preset = 7
 anchor_left = 0.5
 anchor_top = 1.0
@@ -613,11 +977,11 @@ grow_vertical = 0
 theme_override_fonts/font = SubResource("8")
 text = "OK"
 
-[node name="FootprintTilePopup" type="Popup" parent="." unique_id=127790484]
+[node name="FootprintTilePopup" type="Popup" parent="UIElements" unique_id=127790484]
 position = Vector2i(303, 75)
 size = Vector2i(417, 381)
 
-[node name="Title" type="Label" parent="FootprintTilePopup" unique_id=663929269]
+[node name="Title" type="Label" parent="UIElements/FootprintTilePopup" unique_id=663929269]
 anchors_preset = 5
 anchor_left = 0.5
 anchor_right = 0.5
@@ -631,7 +995,7 @@ text = "Alloy Acquired!"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="FootprintTile" type="Label" parent="FootprintTilePopup" unique_id=324370664]
+[node name="FootprintTile" type="Label" parent="UIElements/FootprintTilePopup" unique_id=324370664]
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
@@ -649,7 +1013,7 @@ text = "Electrum"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Info" type="Label" parent="FootprintTilePopup" unique_id=1506722962]
+[node name="Info" type="Label" parent="UIElements/FootprintTilePopup" unique_id=1506722962]
 visible = false
 anchors_preset = 8
 anchor_left = 0.5
@@ -666,7 +1030,7 @@ theme_override_fonts/font = SubResource("7")
 text = "Electrum"
 autowrap_mode = 3
 
-[node name="Close" type="Button" parent="FootprintTilePopup" unique_id=1313648609]
+[node name="Close" type="Button" parent="UIElements/FootprintTilePopup" unique_id=1313648609]
 anchors_preset = 7
 anchor_left = 0.5
 anchor_top = 1.0
@@ -681,7 +1045,7 @@ grow_vertical = 0
 theme_override_fonts/font = SubResource("8")
 text = "OK"
 
-[node name="Description" type="RichTextLabel" parent="FootprintTilePopup" unique_id=1950614225]
+[node name="Description" type="RichTextLabel" parent="UIElements/FootprintTilePopup" unique_id=1950614225]
 offset_left = 22.0
 offset_top = 104.0
 offset_right = 403.0
@@ -704,409 +1068,51 @@ Speak, speak.
 First Citizen:
 You are all resolved rather to die than to famish?"
 
-[node name="CentralDomino" parent="." unique_id=2035090892 instance=ExtResource("8")]
-texture_filter = 1
-position = Vector2(-192, 0)
-scale = Vector2(0.5, 0.5)
-placed = true
+[node name="Settings" parent="UIElements" unique_id=1735084520 instance=ExtResource("6")]
+visible = false
+position = Vector2(-528, -304)
 
-[node name="Sprite2D" parent="CentralDomino" index="0" unique_id=1727582070]
-position = Vector2(8, -112)
-scale = Vector2(0.5, 0.5)
-
-[node name="CollisionShape2D" parent="CentralDomino/Area2D" parent_id_path=PackedInt32Array(2035090892, 1374037218) index="0" unique_id=923412705]
-position = Vector2(8, -112)
-scale = Vector2(0.8, 0.8)
-
-[node name="Place" type="AudioStreamPlayer" parent="." unique_id=594223884]
+[node name="Place" type="AudioStreamPlayer" parent="UIElements" unique_id=594223884]
 stream = ExtResource("12")
 volume_db = -10.0
 
-[node name="Acquire" type="AudioStreamPlayer" parent="." unique_id=745521503]
+[node name="Acquire" type="AudioStreamPlayer" parent="UIElements" unique_id=745521503]
 stream = ExtResource("11")
 volume_db = -5.0
 
-[node name="NextSound" type="AudioStreamPlayer" parent="." unique_id=41311617]
+[node name="NextSound" type="AudioStreamPlayer" parent="UIElements" unique_id=41311617]
 stream = ExtResource("12")
 volume_db = -10.0
 
-[node name="Tower" parent="." unique_id=411159155 instance=ExtResource("15")]
-position = Vector2(-494, -86)
-scale = Vector2(0.2, 0.2)
+[node name="AnimationPlayer" type="AnimationPlayer" parent="." unique_id=369789060]
+libraries/ = SubResource("AnimationLibrary_vh554")
+autoplay = &"Zoom Out"
 
-[node name="SaveButton" parent="." unique_id=1717313087 instance=ExtResource("14")]
-visible = false
-position = Vector2(-186, -222)
-scale = Vector2(0.4, 0.4)
+[connection signal="mouse_entered" from="WorldElements/Start" to="." method="_on_Start_mouse_entered"]
+[connection signal="mouse_exited" from="WorldElements/Start" to="." method="_on_Start_mouse_exited"]
+[connection signal="pressed" from="WorldElements/Start" to="." method="_on_Start_pressed"]
+[connection signal="mouse_entered" from="WorldElements/Reset" to="." method="_on_Reset_mouse_entered"]
+[connection signal="mouse_exited" from="WorldElements/Reset" to="." method="_on_Reset_mouse_exited"]
+[connection signal="pressed" from="WorldElements/Reset" to="." method="_on_Reset_pressed"]
+[connection signal="mouse_entered" from="WorldElements/Code" to="." method="_on_EnterCode_mouse_entered"]
+[connection signal="mouse_exited" from="WorldElements/Code" to="." method="_on_EnterCode_mouse_exited"]
+[connection signal="pressed" from="WorldElements/Code" to="." method="_on_Code_pressed"]
+[connection signal="mouse_entered" from="WorldElements/Next" to="." method="_on_Next_mouse_entered"]
+[connection signal="mouse_exited" from="WorldElements/Next" to="." method="_on_Next_mouse_exited"]
+[connection signal="pressed" from="WorldElements/Next" to="." method="_on_Next_pressed"]
+[connection signal="mouse_entered" from="WorldElements/Help" to="." method="_on_Help_mouse_entered"]
+[connection signal="mouse_exited" from="WorldElements/Help" to="." method="_on_Help_mouse_exited"]
+[connection signal="pressed" from="WorldElements/Help" to="." method="_on_Help_pressed"]
+[connection signal="pressed" from="WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer/MarginContainer/Enter" to="." method="_on_EnterButton_pressed"]
+[connection signal="pressed" from="WorldElements/EnterCodeMenu/X" to="." method="_on_X_pressed"]
+[connection signal="pressed" from="WorldElements/HelpMenu/HelpButton" to="." method="_on_HelpButton_pressed"]
+[connection signal="pressed" from="WorldElements/HelpMenu/HelpImage/CloseButton" to="." method="_on_CloseButton_pressed"]
+[connection signal="pressed" from="WorldElements/HelpMenu/HelpImage/CloseButton" to="." method="_on_Button_pressed"]
+[connection signal="pressed" from="UIElements/AlloyPopup/Close" to="." method="_close_Alloy_popup"]
+[connection signal="pressed" from="UIElements/WellnessBeadPopup/Close" to="." method="_close_WellnessBead_popup"]
+[connection signal="pressed" from="UIElements/FootprintTilePopup/Close" to="." method="_close_FootprintTile_popup"]
 
-[node name="Start" type="TextureButton" parent="." unique_id=1164943152]
-offset_left = -228.0
-offset_top = 132.0
-offset_right = -38.0
-offset_bottom = 181.0
-scale = Vector2(0.4, 0.4)
-mouse_default_cursor_shape = 2
-texture_normal = ExtResource("19")
-texture_pressed = ExtResource("18")
-texture_hover = ExtResource("20")
-
-[node name="MarginContainer" type="MarginContainer" parent="Start" unique_id=1138882031]
-layout_mode = 0
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-theme_override_constants/margin_bottom = 15
-
-[node name="Label" type="Label" parent="Start/MarginContainer" unique_id=2113117972]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-theme_override_colors/font_color = Color(0.666667, 0.666667, 0.666667, 1)
-theme_override_fonts/font = SubResource("11")
-text = "Start"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="Reset" type="TextureButton" parent="." unique_id=1091096365]
-offset_left = -228.0
-offset_top = 156.0
-offset_right = -38.0
-offset_bottom = 205.0
-scale = Vector2(0.4, 0.4)
-mouse_default_cursor_shape = 2
-texture_normal = ExtResource("19")
-texture_pressed = ExtResource("18")
-texture_hover = ExtResource("20")
-
-[node name="MarginContainer" type="MarginContainer" parent="Reset" unique_id=1372665780]
-layout_mode = 0
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-theme_override_constants/margin_bottom = 15
-
-[node name="Label" type="Label" parent="Reset/MarginContainer" unique_id=1863938518]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-theme_override_colors/font_color = Color(0.666667, 0.666667, 0.666667, 1)
-theme_override_fonts/font = SubResource("11")
-text = "Reset"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="Code" type="TextureButton" parent="." unique_id=51973216]
-visible = false
-offset_left = -154.0
-offset_top = -228.0
-offset_right = 36.0
-offset_bottom = -179.0
-scale = Vector2(0.4, 0.4)
-mouse_default_cursor_shape = 2
-texture_normal = ExtResource("19")
-texture_pressed = ExtResource("18")
-texture_hover = ExtResource("20")
-metadata/_edit_use_anchors_ = true
-
-[node name="MarginContainer" type="MarginContainer" parent="Code" unique_id=1256968813]
-layout_mode = 0
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-theme_override_constants/margin_bottom = 15
-
-[node name="Label" type="Label" parent="Code/MarginContainer" unique_id=1068016564]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
-theme_override_fonts/font = SubResource("11")
-text = "Enter Code"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="Next" type="TextureButton" parent="." unique_id=750766444]
-offset_left = -144.0
-offset_top = -232.0
-offset_right = 46.0
-offset_bottom = -183.0
-scale = Vector2(0.4, 0.4)
-mouse_default_cursor_shape = 2
-texture_normal = ExtResource("19")
-texture_pressed = ExtResource("18")
-texture_hover = ExtResource("20")
-metadata/_edit_use_anchors_ = true
-
-[node name="MarginContainer" type="MarginContainer" parent="Next" unique_id=1524833728]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-mouse_filter = 2
-theme_override_constants/margin_bottom = 15
-
-[node name="Label" type="Label" parent="Next/MarginContainer" unique_id=1133366593]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
-theme_override_fonts/font = SubResource("11")
-text = "Next Round"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="Help" type="TextureButton" parent="." unique_id=1604946150]
-offset_left = -372.0
-offset_top = 98.0
-offset_right = -182.0
-offset_bottom = 147.0
-scale = Vector2(0.4, 0.4)
-mouse_default_cursor_shape = 2
-texture_normal = ExtResource("19")
-texture_pressed = ExtResource("18")
-texture_hover = ExtResource("20")
-metadata/_edit_use_anchors_ = true
-
-[node name="MarginContainer" type="MarginContainer" parent="Help" unique_id=753929215]
-layout_mode = 0
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-theme_override_constants/margin_bottom = 15
-
-[node name="Label" type="Label" parent="Help/MarginContainer" unique_id=417630671]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
-theme_override_fonts/font = SubResource("11")
-text = "Need Help"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="EnterCodeMenu" type="NinePatchRect" parent="." unique_id=2094562660]
-visible = false
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -847.0
-offset_top = -495.0
-offset_right = 847.0
-offset_bottom = 495.0
-texture = ExtResource("25")
-region_rect = Rect2(0, 0, 100, 100)
-patch_margin_left = 31
-patch_margin_top = 28
-patch_margin_right = 29
-patch_margin_bottom = 28
-
-[node name="MarginContainer" type="MarginContainer" parent="EnterCodeMenu" unique_id=1367911909]
-layout_mode = 0
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-theme_override_constants/margin_left = 50
-theme_override_constants/margin_top = 100
-theme_override_constants/margin_right = 50
-theme_override_constants/margin_bottom = 100
-
-[node name="VBoxContainer" type="VBoxContainer" parent="EnterCodeMenu/MarginContainer" unique_id=819992936]
-layout_mode = 2
-theme_override_constants/separation = 25
-
-[node name="EnterCode" type="Label" parent="EnterCodeMenu/MarginContainer/VBoxContainer" unique_id=1619657454]
-layout_mode = 2
-theme_override_fonts/font = SubResource("12")
-text = "Enter Code"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="NinePatchRect" type="NinePatchRect" parent="EnterCodeMenu/MarginContainer/VBoxContainer" unique_id=1824846860]
-custom_minimum_size = Vector2(0, 150)
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 0
-size_flags_stretch_ratio = 0.0
-texture = ExtResource("25")
-region_rect = Rect2(-1.09497, -1, 102.095, 102.423)
-patch_margin_left = 3
-patch_margin_top = 7
-patch_margin_right = 3
-patch_margin_bottom = 35
-
-[node name="MarginContainer" type="MarginContainer" parent="EnterCodeMenu/MarginContainer/VBoxContainer/NinePatchRect" unique_id=1533910496]
-layout_mode = 0
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-theme_override_constants/margin_left = 25
-theme_override_constants/margin_right = 25
-
-[node name="LineEdit" type="LineEdit" parent="EnterCodeMenu/MarginContainer/VBoxContainer/NinePatchRect/MarginContainer" unique_id=51159914]
-layout_mode = 2
-theme = ExtResource("17")
-theme_override_colors/font_color = Color(0.533333, 0.533333, 0.533333, 1)
-theme_override_fonts/font = SubResource("14")
-
-[node name="MarginContainer" type="MarginContainer" parent="EnterCodeMenu/MarginContainer/VBoxContainer" unique_id=937920315]
-layout_mode = 2
-mouse_filter = 2
-theme_override_constants/margin_top = 150
-
-[node name="Enter" type="TextureButton" parent="EnterCodeMenu/MarginContainer/VBoxContainer/MarginContainer" unique_id=1946840216]
-custom_minimum_size = Vector2(700, 200)
-layout_mode = 2
-size_flags_horizontal = 6
-mouse_default_cursor_shape = 2
-texture_normal = ExtResource("24")
-texture_pressed = ExtResource("23")
-texture_hover = ExtResource("23")
-
-[node name="MarginContainer" type="MarginContainer" parent="EnterCodeMenu/MarginContainer/VBoxContainer/MarginContainer/Enter" unique_id=612261445]
-layout_mode = 0
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-theme_override_constants/margin_bottom = 25
-
-[node name="Label" type="Label" parent="EnterCodeMenu/MarginContainer/VBoxContainer/MarginContainer/Enter/MarginContainer" unique_id=1386978179]
-layout_mode = 2
-theme = ExtResource("17")
-theme_override_fonts/font = SubResource("13")
-text = "Enter"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="X" type="TextureButton" parent="EnterCodeMenu" unique_id=187524548]
-layout_mode = 0
-offset_left = 1611.0
-offset_top = 25.0
-offset_right = 1665.0
-offset_bottom = 77.0
-mouse_default_cursor_shape = 2
-texture_normal = ExtResource("22")
-texture_pressed = ExtResource("21")
-texture_hover = ExtResource("21")
-
-[node name="InvalidCode" type="Label" parent="EnterCodeMenu" unique_id=1790883149]
-visible = false
-layout_mode = 0
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-offset_top = -42.0
-offset_bottom = 73.0
-theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
-theme_override_fonts/font = SubResource("15")
-text = "Invalid code!"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="UsedCode" type="Label" parent="EnterCodeMenu" unique_id=1267248247]
-visible = false
-layout_mode = 0
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-offset_top = -42.0
-offset_bottom = 73.0
-theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
-theme_override_fonts/font = SubResource("15")
-text = "This code has been used already!"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="AcceptCode" type="Label" parent="EnterCodeMenu" unique_id=405977017]
-visible = false
-layout_mode = 0
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-offset_top = -42.0
-offset_bottom = 73.0
-theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
-theme_override_fonts/font = SubResource("15")
-text = "Code accepted!"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="HelpMenu" type="Control" parent="." unique_id=699493088]
-layout_mode = 3
-anchors_preset = 0
-offset_right = 40.0
-offset_bottom = 40.0
-metadata/_edit_use_anchors_ = true
-
-[node name="HelpButton" type="Button" parent="HelpMenu" unique_id=95552350]
-texture_filter = 1
-layout_mode = 1
-anchors_preset = -1
-anchor_left = 1.6
-anchor_top = 0.75
-anchor_right = 1.6
-anchor_bottom = 0.75
-offset_left = 53.0
-offset_top = -260.0
-offset_right = 255.0
-offset_bottom = -54.0
-scale = Vector2(0.15, 0.15)
-theme_override_styles/normal = SubResource("16")
-theme_override_styles/pressed = SubResource("20")
-theme_override_styles/hover = SubResource("18")
-icon_alignment = 1
-metadata/_edit_use_anchors_ = true
-
-[node name="HelpImage" type="TextureRect" parent="HelpMenu" unique_id=1678077797]
-visible = false
-layout_mode = 0
-offset_left = -506.0
-offset_top = -244.0
-offset_right = 6054.0
-offset_bottom = 4536.0
-scale = Vector2(0.1, 0.1)
-texture = ExtResource("26")
-metadata/_edit_lock_ = true
-
-[node name="CloseButton" type="Button" parent="HelpMenu/HelpImage" unique_id=899241210]
-layout_mode = 0
-offset_left = 6280.0
-offset_top = 80.0
-offset_right = 6444.0
-offset_bottom = 240.0
-theme_override_styles/normal = SubResource("17")
-theme_override_styles/pressed = SubResource("21")
-theme_override_styles/hover = SubResource("19")
-metadata/_edit_lock_ = true
-
-[connection signal="pressed" from="AlloyPopup/Close" to="." method="_close_Alloy_popup"]
-[connection signal="pressed" from="WellnessBeadPopup/Close" to="." method="_close_WellnessBead_popup"]
-[connection signal="pressed" from="FootprintTilePopup/Close" to="." method="_close_FootprintTile_popup"]
-[connection signal="mouse_entered" from="Start" to="." method="_on_Start_mouse_entered"]
-[connection signal="mouse_exited" from="Start" to="." method="_on_Start_mouse_exited"]
-[connection signal="pressed" from="Start" to="." method="_on_Start_pressed"]
-[connection signal="mouse_entered" from="Reset" to="." method="_on_Reset_mouse_entered"]
-[connection signal="mouse_exited" from="Reset" to="." method="_on_Reset_mouse_exited"]
-[connection signal="pressed" from="Reset" to="." method="_on_Reset_pressed"]
-[connection signal="mouse_entered" from="Code" to="." method="_on_EnterCode_mouse_entered"]
-[connection signal="mouse_exited" from="Code" to="." method="_on_EnterCode_mouse_exited"]
-[connection signal="pressed" from="Code" to="." method="_on_Code_pressed"]
-[connection signal="mouse_entered" from="Next" to="." method="_on_Next_mouse_entered"]
-[connection signal="mouse_exited" from="Next" to="." method="_on_Next_mouse_exited"]
-[connection signal="pressed" from="Next" to="." method="_on_Next_pressed"]
-[connection signal="mouse_entered" from="Help" to="." method="_on_Help_mouse_entered"]
-[connection signal="mouse_exited" from="Help" to="." method="_on_Help_mouse_exited"]
-[connection signal="pressed" from="Help" to="." method="_on_Help_pressed"]
-[connection signal="pressed" from="EnterCodeMenu/MarginContainer/VBoxContainer/MarginContainer/Enter" to="." method="_on_EnterButton_pressed"]
-[connection signal="pressed" from="EnterCodeMenu/X" to="." method="_on_X_pressed"]
-[connection signal="pressed" from="HelpMenu/HelpButton" to="." method="_on_HelpButton_pressed"]
-[connection signal="pressed" from="HelpMenu/HelpImage/CloseButton" to="." method="_on_CloseButton_pressed"]
-[connection signal="pressed" from="HelpMenu/HelpImage/CloseButton" to="." method="_on_Button_pressed"]
-
-[editable path="Character Bubble1"]
-[editable path="Character Bubble1/Score"]
-[editable path="Settings"]
-[editable path="CentralDomino"]
+[editable path="WorldElements/Character Bubble1"]
+[editable path="WorldElements/Character Bubble1/Score"]
+[editable path="WorldElements/CentralDomino"]
+[editable path="UIElements/Settings"]

--- a/Scenes/Level_4_DominoWorld/DominoWorld.tscn
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="Texture2D" uid="uid://c7thnwhpiw6xc" path="res://UI/sprites/reference.png" id="1"]
 [ext_resource type="PackedScene" uid="uid://crx57hj081ag0" path="res://Scenes/Components/Character Bubble.tscn" id="3"]
+[ext_resource type="Script" uid="uid://4dmvtajf87yc" path="res://Scenes/Level_4_DominoWorld/camera_2d.gd" id="3_0lvn3"]
 [ext_resource type="Texture2D" uid="uid://belf0op6o2ek2" path="res://UI/sprites/character_sprites/faces/0.png" id="4"]
 [ext_resource type="Texture2D" uid="uid://ftttl40wh16g" path="res://UI/sprites/character_sprites/faces/2.png" id="5"]
 [ext_resource type="PackedScene" uid="uid://cixonnslrnkt" path="res://Scenes/Core/Settings.tscn" id="6"]
@@ -13,6 +14,7 @@
 [ext_resource type="AudioStream" uid="uid://bjdomk6fvs8ts" path="res://audio/effects/next.wav" id="12"]
 [ext_resource type="Texture2D" uid="uid://f3flf06cem8b" path="res://UI/sprites/character_sprites/back_hair/8.png" id="13"]
 [ext_resource type="PackedScene" uid="uid://2qcxgankmj3j" path="res://Scenes/Components/SaveButton.tscn" id="14"]
+[ext_resource type="PackedScene" uid="uid://clj23haf5g65i" path="res://Scenes/Components/AnimatedButton.tscn" id="14_gq41l"]
 [ext_resource type="PackedScene" uid="uid://du60w0816hck7" path="res://Scenes/Level_4_DominoWorld/Tower.tscn" id="15"]
 [ext_resource type="FontFile" uid="uid://cxgxlgqxgek6n" path="res://UI/Fonts/Non_Nunito/domino_font/human_domino.otf" id="16"]
 [ext_resource type="Theme" uid="uid://brneq6bi4fuba" path="res://UI/Miscellaneous/ui_theme.tres" id="17"]
@@ -24,10 +26,87 @@
 [ext_resource type="Texture2D" uid="uid://byy16ybwc3qjx" path="res://UI/Control/green_button01.png" id="23"]
 [ext_resource type="Texture2D" uid="uid://cvync24oqcy7k" path="res://UI/Control/green_button00.png" id="24"]
 [ext_resource type="Texture2D" uid="uid://b0dvssdrdf6g2" path="res://UI/Control/grey_panel.png" id="25"]
-[ext_resource type="Texture2D" uid="uid://c2mtwejs5k33a" path="res://UI/Miscellaneous/DominoHint.png" id="26"]
-[ext_resource type="Texture2D" uid="uid://bpvkpeg5r6ls1" path="res://UI/sprites/help.png" id="27"]
-[ext_resource type="Texture2D" uid="uid://cgb7uykpyjide" path="res://UI/sprites/close.png" id="28"]
 [ext_resource type="PackedScene" uid="uid://onq3cam2n0us" path="res://Scenes/Core/PauseMenu.tscn" id="29_bru2g"]
+
+[sub_resource type="FontFile" id="6"]
+fallbacks = Array[Font]([ExtResource("10"), ExtResource("10")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+
+[sub_resource type="FontFile" id="7"]
+fallbacks = Array[Font]([ExtResource("10"), ExtResource("10")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+
+[sub_resource type="FontFile" id="8"]
+fallbacks = Array[Font]([ExtResource("10"), ExtResource("10")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+
+[sub_resource type="FontFile" id="10"]
+fallbacks = Array[Font]([ExtResource("10"), ExtResource("10")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
 
 [sub_resource type="FontFile" id="11"]
 fallbacks = Array[Font]([ExtResource("16"), ExtResource("16")])
@@ -129,111 +208,7 @@ cache/0/16/0/underline_position = 0.0
 cache/0/16/0/underline_thickness = 0.0
 cache/0/16/0/scale = 1.0
 
-[sub_resource type="StyleBoxTexture" id="16"]
-texture = ExtResource("27")
-region_rect = Rect2(0, 0, 980, 980)
-
-[sub_resource type="StyleBoxTexture" id="20"]
-texture = ExtResource("27")
-region_rect = Rect2(0, 0, 980, 980)
-
-[sub_resource type="StyleBoxTexture" id="18"]
-texture = ExtResource("27")
-region_rect = Rect2(0, 0, 980, 980)
-
-[sub_resource type="StyleBoxTexture" id="17"]
-texture = ExtResource("28")
-region_rect = Rect2(0, 0, 512, 512)
-
-[sub_resource type="StyleBoxTexture" id="21"]
-texture = ExtResource("28")
-region_rect = Rect2(0, 0, 512, 512)
-
-[sub_resource type="StyleBoxTexture" id="19"]
-texture = ExtResource("28")
-region_rect = Rect2(0, 0, 512, 512)
-
 [sub_resource type="FontFile" id="5"]
-fallbacks = Array[Font]([ExtResource("10"), ExtResource("10")])
-subpixel_positioning = 0
-msdf_pixel_range = 14
-msdf_size = 128
-cache/0/variation_coordinates = {}
-cache/0/face_index = 0
-cache/0/embolden = 0.0
-cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
-cache/0/spacing_top = 0
-cache/0/spacing_bottom = 0
-cache/0/spacing_space = 0
-cache/0/spacing_glyph = 0
-cache/0/baseline_offset = 0.0
-cache/0/16/0/ascent = 0.0
-cache/0/16/0/descent = 0.0
-cache/0/16/0/underline_position = 0.0
-cache/0/16/0/underline_thickness = 0.0
-cache/0/16/0/scale = 1.0
-
-[sub_resource type="FontFile" id="6"]
-fallbacks = Array[Font]([ExtResource("10"), ExtResource("10")])
-subpixel_positioning = 0
-msdf_pixel_range = 14
-msdf_size = 128
-cache/0/variation_coordinates = {}
-cache/0/face_index = 0
-cache/0/embolden = 0.0
-cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
-cache/0/spacing_top = 0
-cache/0/spacing_bottom = 0
-cache/0/spacing_space = 0
-cache/0/spacing_glyph = 0
-cache/0/baseline_offset = 0.0
-cache/0/16/0/ascent = 0.0
-cache/0/16/0/descent = 0.0
-cache/0/16/0/underline_position = 0.0
-cache/0/16/0/underline_thickness = 0.0
-cache/0/16/0/scale = 1.0
-
-[sub_resource type="FontFile" id="7"]
-fallbacks = Array[Font]([ExtResource("10"), ExtResource("10")])
-subpixel_positioning = 0
-msdf_pixel_range = 14
-msdf_size = 128
-cache/0/variation_coordinates = {}
-cache/0/face_index = 0
-cache/0/embolden = 0.0
-cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
-cache/0/spacing_top = 0
-cache/0/spacing_bottom = 0
-cache/0/spacing_space = 0
-cache/0/spacing_glyph = 0
-cache/0/baseline_offset = 0.0
-cache/0/16/0/ascent = 0.0
-cache/0/16/0/descent = 0.0
-cache/0/16/0/underline_position = 0.0
-cache/0/16/0/underline_thickness = 0.0
-cache/0/16/0/scale = 1.0
-
-[sub_resource type="FontFile" id="8"]
-fallbacks = Array[Font]([ExtResource("10"), ExtResource("10")])
-subpixel_positioning = 0
-msdf_pixel_range = 14
-msdf_size = 128
-cache/0/variation_coordinates = {}
-cache/0/face_index = 0
-cache/0/embolden = 0.0
-cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
-cache/0/spacing_top = 0
-cache/0/spacing_bottom = 0
-cache/0/spacing_space = 0
-cache/0/spacing_glyph = 0
-cache/0/baseline_offset = 0.0
-cache/0/16/0/ascent = 0.0
-cache/0/16/0/descent = 0.0
-cache/0/16/0/underline_position = 0.0
-cache/0/16/0/underline_thickness = 0.0
-cache/0/16/0/scale = 1.0
-
-[sub_resource type="FontFile" id="10"]
 fallbacks = Array[Font]([ExtResource("10"), ExtResource("10")])
 subpixel_positioning = 0
 msdf_pixel_range = 14
@@ -298,356 +273,15 @@ Domino = ExtResource("8")
 [node name="WorldElements" type="Node2D" parent="." unique_id=1641153460]
 
 [node name="Camera2D" type="Camera2D" parent="WorldElements" unique_id=1077432123]
-position = Vector2(-191.99998, -1.5258789e-05)
-scale = Vector2(0.99999994, 0.99999994)
+position = Vector2(-192, -20)
 zoom = Vector2(2.5, 2.5)
-drag_horizontal_enabled = true
-drag_vertical_enabled = true
-
-[node name="SaveButton" parent="WorldElements" unique_id=1717313087 instance=ExtResource("14")]
-visible = false
-position = Vector2(-186, -222)
-scale = Vector2(0.4, 0.4)
-
-[node name="Start" type="TextureButton" parent="WorldElements" unique_id=1164943152]
-offset_left = -228.0
-offset_top = 132.0
-offset_right = -38.0
-offset_bottom = 181.0
-scale = Vector2(0.4, 0.4)
-mouse_default_cursor_shape = 2
-texture_normal = ExtResource("19")
-texture_pressed = ExtResource("18")
-texture_hover = ExtResource("20")
-
-[node name="MarginContainer" type="MarginContainer" parent="WorldElements/Start" unique_id=1138882031]
-layout_mode = 0
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-theme_override_constants/margin_bottom = 15
-
-[node name="Label" type="Label" parent="WorldElements/Start/MarginContainer" unique_id=2113117972]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-theme_override_colors/font_color = Color(0.666667, 0.666667, 0.666667, 1)
-theme_override_fonts/font = SubResource("11")
-text = "Start"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="Reset" type="TextureButton" parent="WorldElements" unique_id=1091096365]
-offset_left = -228.0
-offset_top = 156.0
-offset_right = -38.0
-offset_bottom = 205.0
-scale = Vector2(0.4, 0.4)
-mouse_default_cursor_shape = 2
-texture_normal = ExtResource("19")
-texture_pressed = ExtResource("18")
-texture_hover = ExtResource("20")
-
-[node name="MarginContainer" type="MarginContainer" parent="WorldElements/Reset" unique_id=1372665780]
-layout_mode = 0
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-theme_override_constants/margin_bottom = 15
-
-[node name="Label" type="Label" parent="WorldElements/Reset/MarginContainer" unique_id=1863938518]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-theme_override_colors/font_color = Color(0.666667, 0.666667, 0.666667, 1)
-theme_override_fonts/font = SubResource("11")
-text = "Reset"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="Code" type="TextureButton" parent="WorldElements" unique_id=51973216]
-visible = false
-offset_left = -154.0
-offset_top = -228.0
-offset_right = 36.0
-offset_bottom = -179.0
-scale = Vector2(0.4, 0.4)
-mouse_default_cursor_shape = 2
-texture_normal = ExtResource("19")
-texture_pressed = ExtResource("18")
-texture_hover = ExtResource("20")
-metadata/_edit_use_anchors_ = true
-
-[node name="MarginContainer" type="MarginContainer" parent="WorldElements/Code" unique_id=1256968813]
-layout_mode = 0
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-theme_override_constants/margin_bottom = 15
-
-[node name="Label" type="Label" parent="WorldElements/Code/MarginContainer" unique_id=1068016564]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
-theme_override_fonts/font = SubResource("11")
-text = "Enter Code"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="Next" type="TextureButton" parent="WorldElements" unique_id=750766444]
-offset_left = -144.0
-offset_top = -232.0
-offset_right = 46.0
-offset_bottom = -183.0
-scale = Vector2(0.4, 0.4)
-mouse_default_cursor_shape = 2
-texture_normal = ExtResource("19")
-texture_pressed = ExtResource("18")
-texture_hover = ExtResource("20")
-
-[node name="MarginContainer" type="MarginContainer" parent="WorldElements/Next" unique_id=1524833728]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-mouse_filter = 2
-theme_override_constants/margin_bottom = 15
-
-[node name="Label" type="Label" parent="WorldElements/Next/MarginContainer" unique_id=1133366593]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
-theme_override_fonts/font = SubResource("11")
-text = "Next Round"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="Help" type="TextureButton" parent="WorldElements" unique_id=1604946150]
-offset_left = -372.0
-offset_top = 98.0
-offset_right = -182.0
-offset_bottom = 147.0
-scale = Vector2(0.4, 0.4)
-mouse_default_cursor_shape = 2
-texture_normal = ExtResource("19")
-texture_pressed = ExtResource("18")
-texture_hover = ExtResource("20")
-
-[node name="MarginContainer" type="MarginContainer" parent="WorldElements/Help" unique_id=753929215]
-layout_mode = 0
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-theme_override_constants/margin_bottom = 15
-
-[node name="Label" type="Label" parent="WorldElements/Help/MarginContainer" unique_id=417630671]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
-theme_override_fonts/font = SubResource("11")
-text = "Need Help"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="EnterCodeMenu" type="NinePatchRect" parent="WorldElements" unique_id=2094562660]
-visible = false
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -847.0
-offset_top = -495.0
-offset_right = 847.0
-offset_bottom = 495.0
-texture = ExtResource("25")
-region_rect = Rect2(0, 0, 100, 100)
-patch_margin_left = 31
-patch_margin_top = 28
-patch_margin_right = 29
-patch_margin_bottom = 28
-
-[node name="MarginContainer" type="MarginContainer" parent="WorldElements/EnterCodeMenu" unique_id=1367911909]
-layout_mode = 0
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-theme_override_constants/margin_left = 50
-theme_override_constants/margin_top = 100
-theme_override_constants/margin_right = 50
-theme_override_constants/margin_bottom = 100
-
-[node name="VBoxContainer" type="VBoxContainer" parent="WorldElements/EnterCodeMenu/MarginContainer" unique_id=819992936]
-layout_mode = 2
-theme_override_constants/separation = 25
-
-[node name="EnterCode" type="Label" parent="WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer" unique_id=1619657454]
-layout_mode = 2
-theme_override_fonts/font = SubResource("12")
-text = "Enter Code"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="NinePatchRect" type="NinePatchRect" parent="WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer" unique_id=1824846860]
-custom_minimum_size = Vector2(0, 150)
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 0
-size_flags_stretch_ratio = 0.0
-texture = ExtResource("25")
-region_rect = Rect2(-1.09497, -1, 102.095, 102.423)
-patch_margin_left = 3
-patch_margin_top = 7
-patch_margin_right = 3
-patch_margin_bottom = 35
-
-[node name="MarginContainer" type="MarginContainer" parent="WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer/NinePatchRect" unique_id=1533910496]
-layout_mode = 0
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-theme_override_constants/margin_left = 25
-theme_override_constants/margin_right = 25
-
-[node name="LineEdit" type="LineEdit" parent="WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer/NinePatchRect/MarginContainer" unique_id=51159914]
-layout_mode = 2
-theme = ExtResource("17")
-theme_override_colors/font_color = Color(0.533333, 0.533333, 0.533333, 1)
-theme_override_fonts/font = SubResource("14")
-
-[node name="MarginContainer" type="MarginContainer" parent="WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer" unique_id=937920315]
-layout_mode = 2
-mouse_filter = 2
-theme_override_constants/margin_top = 150
-
-[node name="Enter" type="TextureButton" parent="WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer/MarginContainer" unique_id=1946840216]
-custom_minimum_size = Vector2(700, 200)
-layout_mode = 2
-size_flags_horizontal = 6
-mouse_default_cursor_shape = 2
-texture_normal = ExtResource("24")
-texture_pressed = ExtResource("23")
-texture_hover = ExtResource("23")
-
-[node name="MarginContainer" type="MarginContainer" parent="WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer/MarginContainer/Enter" unique_id=612261445]
-layout_mode = 0
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-theme_override_constants/margin_bottom = 25
-
-[node name="Label" type="Label" parent="WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer/MarginContainer/Enter/MarginContainer" unique_id=1386978179]
-layout_mode = 2
-theme = ExtResource("17")
-theme_override_fonts/font = SubResource("13")
-text = "Enter"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="X" type="TextureButton" parent="WorldElements/EnterCodeMenu" unique_id=187524548]
-layout_mode = 0
-offset_left = 1611.0
-offset_top = 25.0
-offset_right = 1665.0
-offset_bottom = 77.0
-mouse_default_cursor_shape = 2
-texture_normal = ExtResource("22")
-texture_pressed = ExtResource("21")
-texture_hover = ExtResource("21")
-
-[node name="InvalidCode" type="Label" parent="WorldElements/EnterCodeMenu" unique_id=1790883149]
-visible = false
-layout_mode = 0
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-offset_top = -42.0
-offset_bottom = 73.0
-theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
-theme_override_fonts/font = SubResource("15")
-text = "Invalid code!"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="UsedCode" type="Label" parent="WorldElements/EnterCodeMenu" unique_id=1267248247]
-visible = false
-layout_mode = 0
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-offset_top = -42.0
-offset_bottom = 73.0
-theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
-theme_override_fonts/font = SubResource("15")
-text = "This code has been used already!"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="AcceptCode" type="Label" parent="WorldElements/EnterCodeMenu" unique_id=405977017]
-visible = false
-layout_mode = 0
-anchor_top = 0.5
-anchor_right = 1.0
-anchor_bottom = 0.5
-offset_top = -42.0
-offset_bottom = 73.0
-theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
-theme_override_fonts/font = SubResource("15")
-text = "Code accepted!"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="HelpMenu" type="Control" parent="WorldElements" unique_id=699493088]
-layout_mode = 3
-anchors_preset = 0
-offset_right = 40.0
-offset_bottom = 40.0
-
-[node name="HelpButton" type="Button" parent="WorldElements/HelpMenu" unique_id=95552350]
-texture_filter = 1
-layout_mode = 1
-anchors_preset = -1
-anchor_left = 1.6
-anchor_top = 0.75
-anchor_right = 1.6
-anchor_bottom = 0.75
-offset_left = 53.0
-offset_top = -260.0
-offset_right = 255.0
-offset_bottom = -54.0
-scale = Vector2(0.15, 0.15)
-theme_override_styles/normal = SubResource("16")
-theme_override_styles/pressed = SubResource("20")
-theme_override_styles/hover = SubResource("18")
-icon_alignment = 1
-metadata/_edit_use_anchors_ = true
-
-[node name="HelpImage" type="TextureRect" parent="WorldElements/HelpMenu" unique_id=1678077797]
-visible = false
-layout_mode = 0
-offset_left = -506.0
-offset_top = -244.0
-offset_right = 6054.0
-offset_bottom = 4536.0
-scale = Vector2(0.1, 0.1)
-texture = ExtResource("26")
-metadata/_edit_lock_ = true
-
-[node name="CloseButton" type="Button" parent="WorldElements/HelpMenu/HelpImage" unique_id=899241210]
-layout_mode = 0
-offset_left = 6280.0
-offset_top = 80.0
-offset_right = 6444.0
-offset_bottom = 240.0
-theme_override_styles/normal = SubResource("17")
-theme_override_styles/pressed = SubResource("21")
-theme_override_styles/hover = SubResource("19")
-metadata/_edit_lock_ = true
+limit_left = -506
+limit_top = -250
+limit_right = 314
+limit_bottom = 230
+position_smoothing_enabled = true
+position_smoothing_speed = 10.0
+script = ExtResource("3_0lvn3")
 
 [node name="Board" type="Sprite2D" parent="WorldElements" unique_id=496976469]
 z_index = -3
@@ -736,6 +370,9 @@ position = Vector2(-100, 115)
 [node name="Score" parent="WorldElements/Character Bubble1" index="4" unique_id=1386002985]
 z_index = 2
 
+[node name="Popup" parent="WorldElements/Character Bubble1/Score/Button" index="2"]
+position = Vector2i(0, 0)
+
 [node name="Character Bubble2" parent="WorldElements" unique_id=917609711 instance=ExtResource("3")]
 z_index = -1
 position = Vector2(-302, -98.00001)
@@ -809,11 +446,9 @@ scale = Vector2(0.8, 0.8)
 position = Vector2(-494, -86)
 scale = Vector2(0.2, 0.2)
 
-[node name="UIElements" type="Control" parent="." unique_id=109789685]
-layout_mode = 3
-anchors_preset = 0
-offset_right = 40.0
-offset_bottom = 40.0
+[node name="UIElements" type="CanvasLayer" parent="." unique_id=1619795719]
+scale = Vector2(0.5, 0.5)
+transform = Transform2D(0.5, 0, 0, 0.5, 0, 0)
 
 [node name="PauseCL" type="CanvasLayer" parent="UIElements" unique_id=5341854]
 layer = 15
@@ -821,29 +456,8 @@ layer = 15
 [node name="PauseMenu" parent="UIElements/PauseCL" unique_id=2053464100 instance=ExtResource("29_bru2g")]
 visible = false
 
-[node name="Turn" type="Label" parent="UIElements" unique_id=479130248]
-texture_filter = 1
-layout_mode = 0
-offset_top = -230.0
-offset_right = 140.0
-offset_bottom = -176.0
-theme_override_fonts/font = SubResource("5")
-
-[node name="End" type="Label" parent="UIElements" unique_id=577962459]
-layout_mode = 0
-offset_left = 368.0
-offset_top = -664.0
-offset_right = 1256.0
-offset_bottom = 38.0
-theme_override_fonts/font = SubResource("5")
-text = "Tally Up Your
- Points! 
-(Hover over
-faces to see
-scores)"
-horizontal_alignment = 1
-
 [node name="AlloyPopup" type="Popup" parent="UIElements" unique_id=1417684759]
+oversampling_override = 1.0
 position = Vector2i(303, 75)
 size = Vector2i(417, 381)
 
@@ -911,6 +525,7 @@ theme_override_fonts/font = SubResource("8")
 text = "OK"
 
 [node name="WellnessBeadPopup" type="Popup" parent="UIElements" unique_id=1268130132]
+oversampling_override = 1.0
 position = Vector2i(303, 75)
 size = Vector2i(417, 381)
 
@@ -924,7 +539,7 @@ offset_right = 63.5
 offset_bottom = 68.0
 grow_horizontal = 2
 theme_override_fonts/font = SubResource("6")
-text = "Alloy Acquired!"
+text = "You got a..."
 horizontal_alignment = 1
 vertical_alignment = 1
 
@@ -942,7 +557,7 @@ grow_horizontal = 2
 grow_vertical = 2
 theme_override_colors/font_color = Color(1, 0, 1, 1)
 theme_override_fonts/font = SubResource("6")
-text = "Electrum"
+text = "Wellness Bead!"
 horizontal_alignment = 1
 vertical_alignment = 1
 
@@ -959,8 +574,9 @@ offset_bottom = 87.5
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_fonts/font = SubResource("7")
-text = "Electrum is an alloy of gold and silver.
-It represents ..."
+text = "You helped someone on their path
+and so helped promote community
+wellness!"
 
 [node name="Close" type="Button" parent="UIElements/WellnessBeadPopup" unique_id=402153372]
 anchors_preset = 7
@@ -978,6 +594,7 @@ theme_override_fonts/font = SubResource("8")
 text = "OK"
 
 [node name="FootprintTilePopup" type="Popup" parent="UIElements" unique_id=127790484]
+oversampling_override = 1.0
 position = Vector2i(303, 75)
 size = Vector2i(417, 381)
 
@@ -1068,9 +685,244 @@ Speak, speak.
 First Citizen:
 You are all resolved rather to die than to famish?"
 
-[node name="Settings" parent="UIElements" unique_id=1735084520 instance=ExtResource("6")]
+[node name="HUD" type="VBoxContainer" parent="UIElements" unique_id=811660778]
+anchors_preset = -1
+anchor_right = 2.0
+anchor_bottom = 2.0
+alignment = 1
+
+[node name="TopPanel" type="HBoxContainer" parent="UIElements/HUD" unique_id=1981935793]
+layout_mode = 2
+alignment = 1
+
+[node name="SaveButton" parent="UIElements/HUD/TopPanel" unique_id=1717313087 instance=ExtResource("14")]
+visible = false
+position = Vector2(-93, -111)
+scale = Vector2(0.2, 0.2)
+
+[node name="Next" parent="UIElements/HUD/TopPanel" unique_id=170246650 instance=ExtResource("14_gq41l")]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+text = "Next Round"
+font_color = Color(0, 0.6862745, 0, 1)
+border_color = Color(0, 0.6862745, 0, 1)
+
+[node name="Turn" type="Label" parent="UIElements/HUD/TopPanel" unique_id=479130248]
+texture_filter = 1
+layout_mode = 2
+theme_override_fonts/font = ExtResource("16")
+theme_override_font_sizes/font_size = 32
+
+[node name="Code" type="TextureButton" parent="UIElements/HUD" unique_id=51973216]
+visible = false
+layout_mode = 2
+mouse_default_cursor_shape = 2
+texture_normal = ExtResource("19")
+texture_pressed = ExtResource("18")
+texture_hover = ExtResource("20")
+metadata/_edit_use_anchors_ = true
+
+[node name="MarginContainer" type="MarginContainer" parent="UIElements/HUD/Code" unique_id=1256968813]
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+theme_override_constants/margin_bottom = 15
+
+[node name="Label" type="Label" parent="UIElements/HUD/Code/MarginContainer" unique_id=1068016564]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
+theme_override_fonts/font = SubResource("11")
+text = "Enter Code"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="EnterCodeMenu" type="NinePatchRect" parent="UIElements/HUD" unique_id=2094562660]
+visible = false
+layout_mode = 2
+texture = ExtResource("25")
+region_rect = Rect2(0, 0, 100, 100)
+patch_margin_left = 31
+patch_margin_top = 28
+patch_margin_right = 29
+patch_margin_bottom = 28
+
+[node name="MarginContainer" type="MarginContainer" parent="UIElements/HUD/EnterCodeMenu" unique_id=1367911909]
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+theme_override_constants/margin_left = 50
+theme_override_constants/margin_top = 100
+theme_override_constants/margin_right = 50
+theme_override_constants/margin_bottom = 100
+
+[node name="VBoxContainer" type="VBoxContainer" parent="UIElements/HUD/EnterCodeMenu/MarginContainer" unique_id=819992936]
+layout_mode = 2
+theme_override_constants/separation = 25
+
+[node name="EnterCode" type="Label" parent="UIElements/HUD/EnterCodeMenu/MarginContainer/VBoxContainer" unique_id=1619657454]
+layout_mode = 2
+theme_override_fonts/font = SubResource("12")
+text = "Enter Code"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="NinePatchRect" type="NinePatchRect" parent="UIElements/HUD/EnterCodeMenu/MarginContainer/VBoxContainer" unique_id=1824846860]
+custom_minimum_size = Vector2(0, 150)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 0
+size_flags_stretch_ratio = 0.0
+texture = ExtResource("25")
+region_rect = Rect2(-1.09497, -1, 102.095, 102.423)
+patch_margin_left = 3
+patch_margin_top = 7
+patch_margin_right = 3
+patch_margin_bottom = 35
+
+[node name="MarginContainer" type="MarginContainer" parent="UIElements/HUD/EnterCodeMenu/MarginContainer/VBoxContainer/NinePatchRect" unique_id=1533910496]
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+theme_override_constants/margin_left = 25
+theme_override_constants/margin_right = 25
+
+[node name="LineEdit" type="LineEdit" parent="UIElements/HUD/EnterCodeMenu/MarginContainer/VBoxContainer/NinePatchRect/MarginContainer" unique_id=51159914]
+layout_mode = 2
+theme = ExtResource("17")
+theme_override_colors/font_color = Color(0.533333, 0.533333, 0.533333, 1)
+theme_override_fonts/font = SubResource("14")
+
+[node name="MarginContainer" type="MarginContainer" parent="UIElements/HUD/EnterCodeMenu/MarginContainer/VBoxContainer" unique_id=937920315]
+layout_mode = 2
+mouse_filter = 2
+theme_override_constants/margin_top = 150
+
+[node name="Enter" type="TextureButton" parent="UIElements/HUD/EnterCodeMenu/MarginContainer/VBoxContainer/MarginContainer" unique_id=1946840216]
+custom_minimum_size = Vector2(700, 200)
+layout_mode = 2
+size_flags_horizontal = 6
+mouse_default_cursor_shape = 2
+texture_normal = ExtResource("24")
+texture_pressed = ExtResource("23")
+texture_hover = ExtResource("23")
+
+[node name="MarginContainer" type="MarginContainer" parent="UIElements/HUD/EnterCodeMenu/MarginContainer/VBoxContainer/MarginContainer/Enter" unique_id=612261445]
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+theme_override_constants/margin_bottom = 25
+
+[node name="Label" type="Label" parent="UIElements/HUD/EnterCodeMenu/MarginContainer/VBoxContainer/MarginContainer/Enter/MarginContainer" unique_id=1386978179]
+layout_mode = 2
+theme = ExtResource("17")
+theme_override_fonts/font = SubResource("13")
+text = "Enter"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="X" type="TextureButton" parent="UIElements/HUD/EnterCodeMenu" unique_id=187524548]
+layout_mode = 0
+offset_left = 1611.0
+offset_top = 25.0
+offset_right = 1665.0
+offset_bottom = 77.0
+mouse_default_cursor_shape = 2
+texture_normal = ExtResource("22")
+texture_pressed = ExtResource("21")
+texture_hover = ExtResource("21")
+
+[node name="InvalidCode" type="Label" parent="UIElements/HUD/EnterCodeMenu" unique_id=1790883149]
+visible = false
+layout_mode = 0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_top = -42.0
+offset_bottom = 73.0
+theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
+theme_override_fonts/font = SubResource("15")
+text = "Invalid code!"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="UsedCode" type="Label" parent="UIElements/HUD/EnterCodeMenu" unique_id=1267248247]
+visible = false
+layout_mode = 0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_top = -42.0
+offset_bottom = 73.0
+theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
+theme_override_fonts/font = SubResource("15")
+text = "This code has been used already!"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="AcceptCode" type="Label" parent="UIElements/HUD/EnterCodeMenu" unique_id=405977017]
+visible = false
+layout_mode = 0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_top = -42.0
+offset_bottom = 73.0
+theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
+theme_override_fonts/font = SubResource("15")
+text = "Code accepted!"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="End" type="Label" parent="UIElements/HUD" unique_id=577962459]
+visible = false
+layout_mode = 2
+theme_override_fonts/font = SubResource("5")
+text = "Tally Up Your
+ Points! 
+(Hover over
+faces to see
+scores)"
+horizontal_alignment = 1
+
+[node name="Settings" parent="UIElements/HUD" unique_id=1735084520 instance=ExtResource("6")]
 visible = false
 position = Vector2(-528, -304)
+
+[node name="MarginContainer" type="MarginContainer" parent="UIElements/HUD" unique_id=248228038]
+custom_minimum_size = Vector2(0, 950)
+layout_mode = 2
+
+[node name="BottomPanel" type="HBoxContainer" parent="UIElements/HUD" unique_id=701637445]
+custom_minimum_size = Vector2(0, 51)
+layout_mode = 2
+alignment = 1
+
+[node name="Start" parent="UIElements/HUD/BottomPanel" unique_id=1793244429 instance=ExtResource("14_gq41l")]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+text = "Start"
+font_color = Color(0, 0.6862745, 0, 1)
+border_color = Color(0, 0.6862745, 0, 1)
+
+[node name="Help" parent="UIElements/HUD/BottomPanel" unique_id=93144388 instance=ExtResource("14_gq41l")]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+text = "Need Help"
+font_color = Color(1, 0.48235294, 0, 1)
+border_color = Color(1, 0.48235294, 0, 1)
+
+[node name="Reset" parent="UIElements/HUD/BottomPanel" unique_id=697829354 instance=ExtResource("14_gq41l")]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+text = "Reset"
+font_color = Color(0, 0.6862745, 0, 1)
+border_color = Color(0, 0.6862745, 0, 1)
 
 [node name="Place" type="AudioStreamPlayer" parent="UIElements" unique_id=594223884]
 stream = ExtResource("12")
@@ -1088,31 +940,20 @@ volume_db = -10.0
 libraries/ = SubResource("AnimationLibrary_vh554")
 autoplay = &"Zoom Out"
 
-[connection signal="mouse_entered" from="WorldElements/Start" to="." method="_on_Start_mouse_entered"]
-[connection signal="mouse_exited" from="WorldElements/Start" to="." method="_on_Start_mouse_exited"]
-[connection signal="pressed" from="WorldElements/Start" to="." method="_on_Start_pressed"]
-[connection signal="mouse_entered" from="WorldElements/Reset" to="." method="_on_Reset_mouse_entered"]
-[connection signal="mouse_exited" from="WorldElements/Reset" to="." method="_on_Reset_mouse_exited"]
-[connection signal="pressed" from="WorldElements/Reset" to="." method="_on_Reset_pressed"]
-[connection signal="mouse_entered" from="WorldElements/Code" to="." method="_on_EnterCode_mouse_entered"]
-[connection signal="mouse_exited" from="WorldElements/Code" to="." method="_on_EnterCode_mouse_exited"]
-[connection signal="pressed" from="WorldElements/Code" to="." method="_on_Code_pressed"]
-[connection signal="mouse_entered" from="WorldElements/Next" to="." method="_on_Next_mouse_entered"]
-[connection signal="mouse_exited" from="WorldElements/Next" to="." method="_on_Next_mouse_exited"]
-[connection signal="pressed" from="WorldElements/Next" to="." method="_on_Next_pressed"]
-[connection signal="mouse_entered" from="WorldElements/Help" to="." method="_on_Help_mouse_entered"]
-[connection signal="mouse_exited" from="WorldElements/Help" to="." method="_on_Help_mouse_exited"]
-[connection signal="pressed" from="WorldElements/Help" to="." method="_on_Help_pressed"]
-[connection signal="pressed" from="WorldElements/EnterCodeMenu/MarginContainer/VBoxContainer/MarginContainer/Enter" to="." method="_on_EnterButton_pressed"]
-[connection signal="pressed" from="WorldElements/EnterCodeMenu/X" to="." method="_on_X_pressed"]
-[connection signal="pressed" from="WorldElements/HelpMenu/HelpButton" to="." method="_on_HelpButton_pressed"]
-[connection signal="pressed" from="WorldElements/HelpMenu/HelpImage/CloseButton" to="." method="_on_CloseButton_pressed"]
-[connection signal="pressed" from="WorldElements/HelpMenu/HelpImage/CloseButton" to="." method="_on_Button_pressed"]
 [connection signal="pressed" from="UIElements/AlloyPopup/Close" to="." method="_close_Alloy_popup"]
 [connection signal="pressed" from="UIElements/WellnessBeadPopup/Close" to="." method="_close_WellnessBead_popup"]
 [connection signal="pressed" from="UIElements/FootprintTilePopup/Close" to="." method="_close_FootprintTile_popup"]
+[connection signal="pressed" from="UIElements/HUD/TopPanel/Next" to="." method="_on_Next_pressed"]
+[connection signal="mouse_entered" from="UIElements/HUD/Code" to="." method="_on_EnterCode_mouse_entered"]
+[connection signal="mouse_exited" from="UIElements/HUD/Code" to="." method="_on_EnterCode_mouse_exited"]
+[connection signal="pressed" from="UIElements/HUD/Code" to="." method="_on_Code_pressed"]
+[connection signal="pressed" from="UIElements/HUD/EnterCodeMenu/MarginContainer/VBoxContainer/MarginContainer/Enter" to="." method="_on_EnterButton_pressed"]
+[connection signal="pressed" from="UIElements/HUD/EnterCodeMenu/X" to="." method="_on_X_pressed"]
+[connection signal="pressed" from="UIElements/HUD/BottomPanel/Start" to="." method="_on_Start_pressed"]
+[connection signal="pressed" from="UIElements/HUD/BottomPanel/Help" to="." method="_on_Help_pressed"]
+[connection signal="pressed" from="UIElements/HUD/BottomPanel/Reset" to="." method="_on_Reset_pressed"]
 
 [editable path="WorldElements/Character Bubble1"]
 [editable path="WorldElements/Character Bubble1/Score"]
 [editable path="WorldElements/CentralDomino"]
-[editable path="UIElements/Settings"]
+[editable path="UIElements/HUD/Settings"]

--- a/Scenes/Level_4_DominoWorld/camera_2d.gd
+++ b/Scenes/Level_4_DominoWorld/camera_2d.gd
@@ -1,0 +1,54 @@
+extends Camera2D
+
+var dragging: bool = false
+var velocity: Vector2 = Vector2.ZERO
+var starting_pos: Vector2
+var max_x: int
+var min_x: int
+var max_y: int
+var min_y: int
+
+const CENTER_KEY: Key = KEY_A
+
+
+func _ready() -> void:
+	starting_pos = self.global_position
+	var viewport_size = get_viewport_rect().size
+	var half_width = (viewport_size.x * 0.5) / self.zoom.x
+	var half_height = (viewport_size.y * 0.5) / self.zoom.y
+	min_x = self.limit_left + half_width
+	max_x = self.limit_right - half_width
+	min_y = self.limit_top + half_height
+	max_y = self.limit_bottom - half_height
+
+
+func _process(_delta) -> void:
+	self.global_position -= velocity
+	_clamp_to_bounds()
+	velocity = velocity.lerp(Vector2.ZERO, 0.2)
+
+
+func _clamp_to_bounds() -> void:
+	var clamped_x = clamp(self.global_position.x, min_x, max_x)
+	var clamped_y = clamp(self.global_position.y, min_y, max_y)
+	if clamped_x != self.global_position.x:
+		velocity.x = 0
+	if clamped_y != self.global_position.y:
+		velocity.y = 0
+	self.global_position.x = clamped_x
+	self.global_position.y = clamped_y
+
+
+func _input(event) -> void:
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
+		dragging = event.pressed
+	elif event is InputEventMouseMotion and dragging:
+		velocity = event.relative * self.zoom.x * 0.15
+	elif event is InputEventKey and event.pressed and event.keycode == CENTER_KEY:
+		dragging = false
+		velocity = Vector2.ZERO
+		self.global_position = starting_pos
+
+
+func set_drag(is_dragging: bool) -> void:
+	self.dragging = is_dragging

--- a/Scenes/Level_4_DominoWorld/camera_2d.gd.uid
+++ b/Scenes/Level_4_DominoWorld/camera_2d.gd.uid
@@ -1,0 +1,1 @@
+uid://4dmvtajf87yc


### PR DESCRIPTION
Added functionality to enable the user to click and drag their cursor during the Domino rounds to pan along the playing surface while maintaining the position of the HUD in the viewport. This enhances the visibility of long domino trains that previously went off the screen and became unplayable. Additionally, the user can click the `A` key to re-center the camera on the game board.

`Known Bug` - The separation of the game surface from the UI elements has created issues with the ability to hover over player icons to show their popups. This convention is currently archaic and will be refactored in future changes. However, in an attempt to maintain an up-to-date shared codebase, these changes have been requested to merge before this fix is implemented.