### PR TITLE
DEV-38/41/42: Domino Train Animations, Auto-Terminate Domino Round upon Stalemate, and Skip Turn when No Dominoes Remain

### DIFF
--- a/Scenes/Components/Character Bubble.gd
+++ b/Scenes/Components/Character Bubble.gd
@@ -29,9 +29,8 @@ func _draw() -> void:
 	# Pulsing glow using same sin() pattern as _NextSlotIndicator and Path.gd
 	var alpha := 0.3 + 0.2 * sin(_glow_time * 3.0)
 	var glow_col := Color(_glow_color.r, _glow_color.g, _glow_color.b, alpha)
-	# Draw rounded rect outline around bubble area (local coordinates)
-	var rect := Rect2(-45, -55, 90, 110)
-	draw_rect(rect, glow_col, false, 4.0)
+	# Draw circle outline centered on face sprite (local coordinates)
+	draw_arc(Vector2(0.3, 2.0), 30.0, 0, TAU, 32, glow_col, 3.0)
 
 func setup_character(player_id):
 	my_player_id = player_id

--- a/Scenes/Components/Character Bubble.gd
+++ b/Scenes/Components/Character Bubble.gd
@@ -30,8 +30,15 @@ func _draw() -> void:
 	# Pulsing glow using same sin() pattern as _NextSlotIndicator and Path.gd
 	var alpha := 0.3 + 0.2 * sin(_glow_time * 3.0)
 	var glow_col := Color(_glow_color.r, _glow_color.g, _glow_color.b, alpha)
-	# Draw circle outline centered on face sprite (local coordinates)
-	draw_arc(Vector2(0.3, 2.0), 30.0, 0, TAU, 32, glow_col, 3.0)
+	# Bug 5 fix: center glow on face sprite and compute radius from texture size
+	var face_node: Sprite2D = $face
+	var center := face_node.position
+	var radius := 0.0
+	if face_node.texture:
+		radius = max(face_node.texture.get_width(), face_node.texture.get_height()) * face_node.scale.x * 0.55
+	else:
+		radius = 45.0  # fallback
+	draw_arc(center, radius, 0, TAU, 48, glow_col, 4.0)
 
 func setup_character(player_id):
 	my_player_id = player_id

--- a/Scenes/Components/Character Bubble.gd
+++ b/Scenes/Components/Character Bubble.gd
@@ -6,7 +6,7 @@ var my_player_id = null
 # Glow state (per D-14: pulsing gold glow for active player turn indicator)
 var _glow_active := false
 var _glow_time := 0.0
-var _glow_color := Color(1.0, 0.85, 0.0, 0.7)  # warm gold
+var _glow_color := Color(0.1, 0.9, 0.2, 0.7)  # green
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:

--- a/Scenes/Components/Character Bubble.gd
+++ b/Scenes/Components/Character Bubble.gd
@@ -3,9 +3,35 @@ extends Node2D
 
 var my_player_id = null
 
+# Glow state (per D-14: pulsing gold glow for active player turn indicator)
+var _glow_active := false
+var _glow_time := 0.0
+var _glow_color := Color(1.0, 0.85, 0.0, 0.7)  # warm gold
+
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	pass
+	set_process(false)
+
+func set_active_glow(active: bool) -> void:
+	_glow_active = active
+	_glow_time = 0.0
+	set_process(active)
+	queue_redraw()
+
+func _process(delta: float) -> void:
+	if _glow_active:
+		_glow_time += delta
+		queue_redraw()
+
+func _draw() -> void:
+	if not _glow_active:
+		return
+	# Pulsing glow using same sin() pattern as _NextSlotIndicator and Path.gd
+	var alpha := 0.3 + 0.2 * sin(_glow_time * 3.0)
+	var glow_col := Color(_glow_color.r, _glow_color.g, _glow_color.b, alpha)
+	# Draw rounded rect outline around bubble area (local coordinates)
+	var rect := Rect2(-45, -55, 90, 110)
+	draw_rect(rect, glow_col, false, 4.0)
 
 func setup_character(player_id):
 	my_player_id = player_id

--- a/Scenes/Components/Path.gd
+++ b/Scenes/Components/Path.gd
@@ -84,11 +84,16 @@ func _update_visual() -> void:
 	if was_active != _indicator_active or _indicator_active:
 		queue_redraw()
 
+
+func disable(is_disabled: bool) -> void:
+	$Area2D/CollisionShape2D.disabled = is_disabled
+
 # handle placing domino if domino is placed on to path
 func _on_Area2D_input_event(viewport: Node, event: InputEvent, shape_idx: int) -> void:
 	if event is InputEventMouseButton:
 		if event.pressed:
 			get_parent().get_parent().place_domino(num)
+
 
 func _on_Area2D_mouse_entered() -> void:
 	if not _indicator_active:
@@ -97,6 +102,7 @@ func _on_Area2D_mouse_entered() -> void:
 		_hover_tween.kill()
 	_hover_tween = create_tween()
 	_hover_tween.tween_property(self, "scale", _base_scale * 1.1, 0.1).set_ease(Tween.EASE_OUT)
+
 
 func _on_Area2D_mouse_exited() -> void:
 	if _hover_tween:

--- a/Scenes/Components/Path.tscn
+++ b/Scenes/Components/Path.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3 uid="uid://dejvxq7nbxxxf"]
+[gd_scene format=3 uid="uid://dejvxq7nbxxxf"]
 
 [ext_resource type="Texture2D" uid="uid://d0uqyedhohbqh" path="res://UI/sprites/elcitrap.png" id="1"]
 [ext_resource type="Script" uid="uid://cyujx5y8r27gr" path="res://Scenes/Components/Path.gd" id="2"]
@@ -6,15 +6,15 @@
 [sub_resource type="CircleShape2D" id="1"]
 radius = 590.085
 
-[node name="Path2D" type="Sprite2D"]
+[node name="Path2D" type="Sprite2D" unique_id=782846768]
 scale = Vector2(0.1, 0.1)
 texture = ExtResource("1")
 script = ExtResource("2")
 
-[node name="Area2D" type="Area2D" parent="."]
+[node name="Area2D" type="Area2D" parent="." unique_id=1881454765]
 scale = Vector2(1.5, 1.5)
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D" unique_id=1604561348]
 shape = SubResource("1")
 
 [connection signal="input_event" from="Area2D" to="." method="_on_Area2D_input_event"]

--- a/Scenes/Level_4_DominoWorld/DominoWorld.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.gd
@@ -913,7 +913,14 @@ func replace_domino():
 	# load center domino
 	var domino_title = ReferenceManager.get_reference("dominos/" + str(center_num) + str(center_num) + ".png")
 	$CentralDomino.get_node("Sprite2D").texture = load(domino_title)
-	
+
+	# Per D-07: fade and scale-in the new center domino
+	$CentralDomino.modulate.a = 0.0
+	$CentralDomino.scale = Vector2(0.5, 0.5)
+	var center_tween := create_tween().set_parallel(true)
+	center_tween.tween_property($CentralDomino, "modulate:a", 1.0, 0.4)
+	center_tween.tween_property($CentralDomino, "scale", Vector2(1.0, 1.0), 0.4).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BACK)
+
 	var center_area := $CentralDomino.get_node_or_null("Area2D")
 	if center_area:
 		center_area.input_pickable = false
@@ -1036,7 +1043,13 @@ func _update_turn_label():
 	$Turn.text = current_name + "'s\nTurn"
 	# Only show the "Need Help" button if it is currently YOUR turn
 	$Help.visible = (turn == self_num)
-	
+
+	# Per D-14: toggle active player bubble glow
+	for i in range(sorted_players.size()):
+		var bubble := get_node_or_null("Character Bubble" + str(i + 1))
+		if bubble and bubble.has_method("set_active_glow"):
+			bubble.set_active_glow(i == turn)
+
 	# CPU TURN AUTOMATION (HOST ONLY)
 	if str(current_name).contains("CPU") and multiplayer.is_server():
 		_execute_cpu_turn_async(current_player_id)
@@ -1153,26 +1166,33 @@ func intialize_tower():
 	$Tower/Sprite2D/Humanities.visible = false
 	$Tower/Sprite2D/Diamond.visible = false
 
+# Per D-08: fade-in a tower layer node instead of instant visible
+func _animate_tower_layer(node: Node) -> void:
+	node.visible = true
+	node.modulate.a = 0.0
+	var tween := create_tween()
+	tween.tween_property(node, "modulate:a", 1.0, 0.35).set_ease(Tween.EASE_IN)
+
 # Display tower
 func add_tower(round_num):
 	if round_num == 6:
-		$Tower/Sprite2D/Energy.visible = true
-		$Tower/Sprite2D/Stability.visible = true
-		$Tower/Sprite2D/Prepared_Enviroment.visible = true
+		_animate_tower_layer($Tower/Sprite2D/Energy)
+		_animate_tower_layer($Tower/Sprite2D/Stability)
+		_animate_tower_layer($Tower/Sprite2D/Prepared_Enviroment)
 	elif round_num == 7:
-		$Tower/Sprite2D/Ability.visible = true
-		$Tower/Sprite2D/Responsibility.visible = true
-		$Tower/Sprite2D/Perception.visible = true
+		_animate_tower_layer($Tower/Sprite2D/Ability)
+		_animate_tower_layer($Tower/Sprite2D/Responsibility)
+		_animate_tower_layer($Tower/Sprite2D/Perception)
 	elif round_num == 8:
-		$Tower/Sprite2D/Resilience.visible = true
-		$Tower/Sprite2D/Relationship.visible = true
-		$Tower/Sprite2D/Discernment.visible = true
+		_animate_tower_layer($Tower/Sprite2D/Resilience)
+		_animate_tower_layer($Tower/Sprite2D/Relationship)
+		_animate_tower_layer($Tower/Sprite2D/Discernment)
 	elif round_num == 9:
-		$Tower/Sprite2D/Arts.visible = true
-		$Tower/Sprite2D/Sciences.visible = true
-		$Tower/Sprite2D/Humanities.visible = true
+		_animate_tower_layer($Tower/Sprite2D/Arts)
+		_animate_tower_layer($Tower/Sprite2D/Sciences)
+		_animate_tower_layer($Tower/Sprite2D/Humanities)
 	elif round_num == 10:
-		$Tower/Sprite2D/Diamond.visible = true
+		_animate_tower_layer($Tower/Sprite2D/Diamond)
 
 func _on_Help_pressed() -> void:
 	if turn == self_num:

--- a/Scenes/Level_4_DominoWorld/DominoWorld.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.gd
@@ -39,6 +39,8 @@ var center_num = 0 # current round number
 var num_placed = 0
 
 var cpu_hands = {} # The Host stores CPU hands here
+var all_player_hands = {}  # Host tracks ALL player hands (human + CPU) for stalemate detection
+var _consecutive_help_count := 0  # Tracks consecutive Help presses without a placement
 
 # (Fall 2025) added variables
 var can_place = true # to check if currently selected domino is a double
@@ -362,6 +364,7 @@ func setup_dominos():
 	var my_hand = []
 	for i in range(9):
 		my_hand.append(dominos.pop_front())
+	all_player_hands[1] = my_hand.duplicate(true)
 
 	# Deal for Clients and CPUs
 	for p in gamestate.players:
@@ -369,13 +372,16 @@ func setup_dominos():
 			var client_hand = []
 			for i in range(9):
 				client_hand.append(dominos.pop_front())
-				
+
+			# Store ALL player hands on host for stalemate detection (before CPU/human branching)
+			all_player_hands[p] = client_hand.duplicate(true)
+
 			if str(gamestate.players[p]).contains("CPU"):
 				var double_count = 0
 				for d in client_hand:
 					if d[0] == d[1]: double_count += 1
 					if d[0] < d[1]: d.reverse()
-					
+
 				# Reshuffle if 4+ doubles
 				if double_count >= 4:
 					dominos.append_array(client_hand)
@@ -385,8 +391,9 @@ func setup_dominos():
 						var replacement = dominos.pop_front()
 						if replacement[0] < replacement[1]: replacement.reverse()
 						client_hand.append(replacement)
-						
-				cpu_hands[p] = client_hand 
+
+				cpu_hands[p] = client_hand
+				all_player_hands[p] = client_hand.duplicate(true)
 			else:
 				rpc_id(p, "receive_hand", client_hand)
 			
@@ -595,6 +602,15 @@ func place_domino(num):
 
 		hand_dominos.erase([selected_domino.top_num, selected_domino.bottom_num])
 		hand_dominos.erase([selected_domino.bottom_num, selected_domino.top_num])
+		if multiplayer.is_server():
+			# Update host tracking: remove placed domino from local player's tracked hand
+			var placed_pair = [selected_domino.top_num, selected_domino.bottom_num]
+			if all_player_hands.has(multiplayer.get_unique_id()):
+				for i in range(all_player_hands[multiplayer.get_unique_id()].size()):
+					var h = all_player_hands[multiplayer.get_unique_id()][i]
+					if (h[0] == placed_pair[0] and h[1] == placed_pair[1]) or (h[0] == placed_pair[1] and h[1] == placed_pair[0]):
+						all_player_hands[multiplayer.get_unique_id()].remove_at(i)
+						break
 		rearrange_hand()
 
 		if true_top == true_bot:
@@ -797,6 +813,16 @@ func display_footprint_tile(round_num: int, footprint_num: int) -> void:
 
 	end_dominos[path_num] = domino
 	path_step_count[path_num] += 1
+	_consecutive_help_count = 0
+	if multiplayer.is_server():
+		var sender_id = multiplayer.get_remote_sender_id()
+		if sender_id != 0 and all_player_hands.has(sender_id):
+			# Remove the placed domino from tracked hand using domino_nums [bot, top]
+			for i in range(all_player_hands[sender_id].size()):
+				var h = all_player_hands[sender_id][i]
+				if (h[0] == domino_nums[0] and h[1] == domino_nums[1]) or (h[0] == domino_nums[1] and h[1] == domino_nums[0]):
+					all_player_hands[sender_id].remove_at(i)
+					break
 
 # replace placed domino with one from the deck
 func replace_domino():
@@ -824,6 +850,8 @@ func replace_domino():
 	
 	# remove all old dominos from screen
 	num_placed = 0
+	_consecutive_help_count = 0
+	all_player_hands.clear()
 	path_step_count = [0, 0, 0, 0, 0, 0, 0, 0]
 	var group_dominos = get_tree().get_nodes_in_group("dominos")
 	clear_selected_domino()
@@ -932,6 +960,54 @@ func calculate_cpu_move(cpu_id):
 					
 	return null
 
+# True stalemate check: returns true if NO player has ANY valid move on ANY accessible path
+# Called on host only. Per D-09, reuses calculate_cpu_move matching logic.
+func _check_stalemate() -> bool:
+	if not multiplayer.is_server():
+		return false
+	for idx in range(sorted_players.size()):
+		var pid = sorted_players[idx]
+		var player_hand = []
+		if all_player_hands.has(pid):
+			player_hand = all_player_hands[pid]
+		elif cpu_hands.has(pid):
+			player_hand = cpu_hands[pid]
+		else:
+			return false  # Unknown hand, assume not stuck
+		if player_hand.size() == 0:
+			continue  # No dominos left, can't move but not blocking
+		for domino_pair in player_hand:
+			# Check personal path
+			if domino_pair[0] == path_ends[idx] or domino_pair[1] == path_ends[idx]:
+				return false
+			# Check open trains (other player paths)
+			for p_idx in range(6):
+				if p_idx != idx and train_open[p_idx]:
+					if domino_pair[0] == path_ends[p_idx] or domino_pair[1] == path_ends[p_idx]:
+						return false
+			# Check sun paths (indices 6 and 7)
+			for sun_idx in [6, 7]:
+				if domino_pair[0] == path_ends[sun_idx] or domino_pair[1] == path_ends[sun_idx]:
+					return false
+	return true
+
+func _trigger_stalemate() -> void:
+	if not multiplayer.is_server():
+		return
+	rpc("show_stalemate_popup")
+
+@rpc("authority", "call_local") func show_stalemate_popup():
+	$StalematePopup.visible = true
+	await get_tree().create_timer(3.0).timeout
+	$StalematePopup.visible = false
+	# All peers call next_round() locally — show_stalemate_popup already runs on
+	# all peers via @rpc("authority", "call_local"), so no additional rpc_id calls needed.
+	# Host-only code inside next_round() (like setup_dominos) is already guarded
+	# by multiplayer.is_server().
+	next_round()
+	if multiplayer.is_server() and center_num <= 9:
+		setup_dominos()
+
 @rpc("any_peer") func sync_turn(new_turn):
 	turn = new_turn
 	_update_turn_label()
@@ -939,6 +1015,8 @@ func calculate_cpu_move(cpu_id):
 @rpc("any_peer") func advance_turn():
 	turn = (turn + 1) % len(gamestate.players)
 	_update_turn_label()
+	if multiplayer.is_server() and _check_stalemate():
+		_trigger_stalemate()
 
 func _update_turn_label():
 	var current_player_id = sorted_players[turn]
@@ -995,7 +1073,9 @@ func _execute_cpu_turn_async(cpu_id):
 			display_wellness_prompt()
 			
 		cpu_hands[cpu_id].remove_at(move.hand_idx)
-		
+		if all_player_hands.has(cpu_id):
+			all_player_hands[cpu_id].remove_at(move.hand_idx)
+
 		if move.path_idx == my_path_idx and train_open[my_path_idx]:
 			rpc("set_train_open", my_path_idx, false)
 			set_train_open(my_path_idx, false)
@@ -1087,6 +1167,10 @@ func _on_Help_pressed() -> void:
 		advance_turn()
 		can_place = true
 		SFXController.playSFX(ReferenceManager.get_reference("next.wav"))
+		_consecutive_help_count += 1
+		if multiplayer.is_server() and _consecutive_help_count >= len(sorted_players):
+			_trigger_stalemate()
+			return
 
 @rpc("any_peer") func add_path(num):
 	var path_node = get_node_or_null("Path" + str(num))

--- a/Scenes/Level_4_DominoWorld/DominoWorld.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.gd
@@ -43,6 +43,7 @@ var num_placed = 0
 var cpu_hands = {} # The Host stores CPU hands here
 var all_player_hands = {}  # Host tracks ALL player hands (human + CPU) for stalemate detection
 var _consecutive_help_count := 0  # Tracks consecutive Help presses without a placement
+var _round_advancing := false  # Re-entrancy guard for next_round() (Bug 3 fix)
 
 # (Fall 2025) added variables
 var can_place = true # to check if currently selected domino is a double
@@ -333,7 +334,8 @@ func _init_players() -> void:
 
 func _on_Start_pressed() -> void:
 	if (SaveManager.loaded_data):
-		for i in range(0, SaveManager.Save["0"].Current_Round):
+		var rounds_to_skip: int = SaveManager.Save["0"].Current_Round
+		for i in range(0, rounds_to_skip):
 			next_round()
 	else:
 		SaveManager.Save["0"].Current_Round = 0
@@ -863,6 +865,10 @@ func replace_domino():
 
 # go to next round of play
 @rpc("any_peer") func next_round():
+	# Re-entrancy guard: prevent double-advance (Bug 3 fix — _round_advancing flag)
+	if _round_advancing:
+		return
+	_round_advancing = true
 	# show all footprint tiles from this round
 	footprint_tile_ring.show_round(center_num)
 	
@@ -889,6 +895,7 @@ func replace_domino():
 		else:
 			reset_button.visible = false
 		center_num += 1
+		_round_advancing = false
 		return
 	dominos = [] + gamestate.dominos
 	dominos.shuffle()
@@ -932,6 +939,7 @@ func replace_domino():
 	
 	# Set a new random player's turn
 	randomize_turn()
+	_round_advancing = false
 
 # Evaluates the CPU's hand and returns the best valid move
 func calculate_cpu_move(cpu_id):
@@ -1007,6 +1015,7 @@ func _trigger_stalemate() -> void:
 
 @rpc("authority", "call_local") func show_stalemate_popup():
 	$UIElements/StalematePopup.visible = true
+	next_button.visible = false  # Prevent Next press during stalemate auto-advance (Bug 3 fix)
 	await get_tree().create_timer(3.0).timeout
 	$UIElements/StalematePopup.visible = false
 	# All peers call next_round() locally — show_stalemate_popup already runs on

--- a/Scenes/Level_4_DominoWorld/DominoWorld.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.gd
@@ -44,6 +44,7 @@ var cpu_hands = {} # The Host stores CPU hands here
 var all_player_hands = {}  # Host tracks ALL player hands (human + CPU) for stalemate detection
 var _consecutive_help_count := 0  # Tracks consecutive Help presses without a placement
 var _round_advancing := false  # Re-entrancy guard for next_round() (Bug 3 fix)
+var _stalemate_in_progress := false  # Prevents multiple stalemate triggers per round
 
 # (Fall 2025) added variables
 var can_place = true # to check if currently selected domino is a double
@@ -579,15 +580,17 @@ func place_domino(num):
 		# Capture reference before await — selected_domino can become null during yield
 		var placed_domino = selected_domino
 
-		# Bug 1 fix: save global_position before reparenting — reparenting changes it
-		var saved_global_pos = placed_domino.global_position
+		# Bug 1 fix: UIElements is a CanvasLayer (screen coords), WorldElements uses world coords.
+		# Save screen position before reparenting, then convert to world coords after.
+		var screen_pos = placed_domino.global_position
 
 		# Reparent from UIElements to WorldElements before animating (D-20 pattern)
 		ui_elements.remove_child(placed_domino)
 		world_elements.add_child(placed_domino)
 
-		# Bug 1 fix: restore the hand position so animation starts from correct origin
-		placed_domino.global_position = saved_global_pos
+		# Bug 1 fix: convert screen coords → world coords using the canvas transform
+		# (which includes Camera2D offset/zoom for the default canvas layer)
+		placed_domino.global_position = placed_domino.get_canvas_transform().affine_inverse() * screen_pos
 
 		placed_domino.mark_as_placed(PLACED_SCALE)
 		var target_pos = _path_position_for_step(num, path_step_count[num])
@@ -874,10 +877,11 @@ func replace_domino():
 
 # go to next round of play
 @rpc("any_peer") func next_round():
-	# Re-entrancy guard: prevent double-advance (Bug 3 fix — _round_advancing flag)
+	# Re-entrancy guard: prevent double-advance (Bug 3 fix)
 	if _round_advancing:
 		return
 	_round_advancing = true
+	_stalemate_in_progress = false  # Reset stalemate flag for new round
 	# show all footprint tiles from this round
 	footprint_tile_ring.show_round(center_num)
 	
@@ -1020,20 +1024,23 @@ func _check_stalemate() -> bool:
 func _trigger_stalemate() -> void:
 	if not multiplayer.is_server():
 		return
+	if _stalemate_in_progress:
+		return
+	_stalemate_in_progress = true
 	rpc("show_stalemate_popup")
 
 @rpc("authority", "call_local") func show_stalemate_popup():
 	$UIElements/StalematePopup.visible = true
-	next_button.visible = false  # Prevent Next press during stalemate auto-advance (Bug 3 fix)
+	next_button.visible = false  # Prevent Next press during stalemate auto-advance
 	await get_tree().create_timer(3.0).timeout
 	$UIElements/StalematePopup.visible = false
-	# All peers call next_round() locally — show_stalemate_popup already runs on
-	# all peers via @rpc("authority", "call_local"), so no additional rpc_id calls needed.
-	# Host-only code inside next_round() (like setup_dominos) is already guarded
-	# by multiplayer.is_server().
 	next_round()
+	_stalemate_in_progress = false  # Reset so future rounds can detect stalemate
 	if multiplayer.is_server() and center_num <= 9:
 		setup_dominos()
+	# Re-show Next button for the host after auto-advance completes
+	if multiplayer.is_server():
+		next_button.visible = true
 
 @rpc("any_peer") func sync_turn(new_turn):
 	turn = new_turn
@@ -1207,14 +1214,16 @@ func add_tower(round_num):
 func _on_Help_pressed() -> void:
 	if turn == self_num:
 		rpc("set_train_open", self_num, true)
+		_consecutive_help_count += 1
+		# Check consecutive help BEFORE advance_turn to avoid double-triggering stalemate.
+		# advance_turn() also checks _check_stalemate(), so only one path should fire.
+		if multiplayer.is_server() and _consecutive_help_count >= len(sorted_players):
+			_trigger_stalemate()
+			return
 		rpc("advance_turn")
 		advance_turn()
 		can_place = true
 		SFXController.playSFX(ReferenceManager.get_reference("next.wav"))
-		_consecutive_help_count += 1
-		if multiplayer.is_server() and _consecutive_help_count >= len(sorted_players):
-			_trigger_stalemate()
-			return
 
 @rpc("any_peer") func add_path(num):
 	var path_node = get_node_or_null("WorldElements/Path" + str(num))

--- a/Scenes/Level_4_DominoWorld/DominoWorld.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.gd
@@ -470,8 +470,9 @@ func rearrange_hand() -> void:
 	var hand_center_x: float = -192.0
 	for i in range(hand_count):
 		var new_pos := Vector2(hand_center_x + (i * HAND_SPACING) - (total_width / 2.0), 175)
-		var tween := unplaced[i].create_tween()
+		var tween: Tween = create_tween()
 		tween.tween_property(unplaced[i], "position", new_pos, 0.2).set_ease(Tween.EASE_OUT)
+		unplaced[i].set_meta("_rearrange_tween", tween)
 		unplaced[i].original_pos = new_pos
 
 # path set-up
@@ -574,37 +575,38 @@ func place_domino(num):
 		# Force the domino to initialize correctly so the texture syncs with math
 		selected_domino.init(true_top, true_bot, top_el, bot_el, false)
 
-		# Place locally — animate slide (and flip if needed) before advancing turn
-		selected_domino.mark_as_placed(PLACED_SCALE)
+		# Capture reference before await — selected_domino can become null during yield
+		var placed_domino = selected_domino
+
+		# Place locally — animate slide, rotation, and flip before advancing turn
+		placed_domino.mark_as_placed(PLACED_SCALE)
 		var target_pos = _path_position_for_step(num, path_step_count[num])
-		# Set orientation immediately (path angle rotation)
-		_orient_to_path(selected_domino, num)
-		# Per D-01, D-04, D-06: animate slide (and flip if needed) before advancing turn
-		await _animate_placement(selected_domino, target_pos, flip)
+		var target_rot = deg_to_rad(PATH_ANGLE_DEGREES[num] + ROTATION_OFFSET_DEG)
+		await _animate_placement(placed_domino, target_pos, flip, target_rot)
 
 		# Update path ends
 		if flip:
 			path_ends[num] = true_bot
-			selected_domino.top_element = bot_el # Store outward element for next domino
+			placed_domino.top_element = bot_el # Store outward element for next domino
 		else:
 			path_ends[num] = true_top
-			selected_domino.top_element = top_el
+			placed_domino.top_element = top_el
 
-		end_dominos[num] = selected_domino
+		end_dominos[num] = placed_domino
 		path_step_count[num] += 1
 		num_placed += 1
-		
+
 		if num == self_num and train_open[self_num]:
 			rpc("set_train_open", self_num, false)
-		
+
 		# Broadcast the exact placement to everyone
 		rpc("update_domino_path", [true_bot, true_top], [bot_el, top_el], position_table[num], num, flip)
 
-		hand_dominos.erase([selected_domino.top_num, selected_domino.bottom_num])
-		hand_dominos.erase([selected_domino.bottom_num, selected_domino.top_num])
+		hand_dominos.erase([placed_domino.top_num, placed_domino.bottom_num])
+		hand_dominos.erase([placed_domino.bottom_num, placed_domino.top_num])
 		if multiplayer.is_server():
 			# Update host tracking: remove placed domino from local player's tracked hand
-			var placed_pair = [selected_domino.top_num, selected_domino.bottom_num]
+			var placed_pair = [placed_domino.top_num, placed_domino.bottom_num]
 			if all_player_hands.has(multiplayer.get_unique_id()):
 				for i in range(all_player_hands[multiplayer.get_unique_id()].size()):
 					var h = all_player_hands[multiplayer.get_unique_id()][i]
@@ -726,9 +728,10 @@ func increment_total(num):
 
 # display wellness bead popup
 func display_wellness_prompt():
-	$WellnessBeadPopup/Title.text = "You Got a..."
+	var player_name = gamestate.players[sorted_players[turn]] if turn < sorted_players.size() else "Unknown"
+	$WellnessBeadPopup/Title.text = str(player_name) + " Got a..."
 	$WellnessBeadPopup/WellnessBead.text = "Wellness Bead!"
-	$WellnessBeadPopup/Info.text = "You helped someone on their path and so helped promote community wellness!"
+	$WellnessBeadPopup/Info.text = str(player_name) + " helped someone on their path and so helped promote community wellness!"
 	$WellnessBeadPopup.visible = true
 
 
@@ -747,7 +750,8 @@ func display_wellness_prompt():
 	gamestate.alloys[num] = int(get_node(path).text)
 	increment_total(num)
 	
-	$AlloyPopup/Title.text = "Alloy Acquired!"
+	var player_name = gamestate.players[sorted_players[turn]] if turn < sorted_players.size() else "Unknown"
+	$AlloyPopup/Title.text = str(player_name) + " earned an Alloy!"
 	$AlloyPopup/Alloy.text = alloy
 	$AlloyPopup/Info.text = curriculum.alloy_table[alloy]
 	$AlloyPopup.visible = true
@@ -808,7 +812,7 @@ func display_footprint_tile(round_num: int, footprint_num: int) -> void:
 	else:
 		domino.global_position = _path_position_for_step(path_num, path_step_count[path_num])
 	var target_pos = _path_position_for_step(path_num, path_step_count[path_num])
-	_orient_to_path(domino, path_num)
+	var target_rot = deg_to_rad(PATH_ANGLE_DEGREES[path_num] + ROTATION_OFFSET_DEG)
 
 	# Flawless Flip logic — path_ends and top_element set before animation
 	if flip:
@@ -818,9 +822,9 @@ func display_footprint_tile(round_num: int, footprint_num: int) -> void:
 		path_ends[path_num] = top_n
 		domino.top_element = top_e
 
-	# Animate slide (and flip if needed) — no await since turn advancement
+	# Animate slide, rotation, and flip — no await since turn advancement
 	# is controlled by the host, not by this RPC handler
-	_animate_placement(domino, target_pos, flip)
+	_animate_placement(domino, target_pos, flip, target_rot)
 
 	end_dominos[path_num] = domino
 	path_step_count[path_num] += 1
@@ -910,16 +914,16 @@ func replace_domino():
 		path_ends.append(center_num)
 	end_dominos = [null, null, null, null, null, null, null, null]
 
+	# Per D-07: hide before loading new texture to prevent one-frame flash
+	$CentralDomino.modulate.a = 0.0
+	$CentralDomino.scale = Vector2(0.25, 0.25)
+
 	# load center domino
 	var domino_title = ReferenceManager.get_reference("dominos/" + str(center_num) + str(center_num) + ".png")
 	$CentralDomino.get_node("Sprite2D").texture = load(domino_title)
-
-	# Per D-07: fade and scale-in the new center domino
-	$CentralDomino.modulate.a = 0.0
-	$CentralDomino.scale = Vector2(0.5, 0.5)
-	var center_tween := create_tween().set_parallel(true)
+	var center_tween: Tween = create_tween().set_parallel(true)
 	center_tween.tween_property($CentralDomino, "modulate:a", 1.0, 0.4)
-	center_tween.tween_property($CentralDomino, "scale", Vector2(1.0, 1.0), 0.4).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BACK)
+	center_tween.tween_property($CentralDomino, "scale", Vector2(0.5, 0.5), 0.4).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BACK)
 
 	var center_area := $CentralDomino.get_node_or_null("Area2D")
 	if center_area:
@@ -1170,7 +1174,7 @@ func intialize_tower():
 func _animate_tower_layer(node: Node) -> void:
 	node.visible = true
 	node.modulate.a = 0.0
-	var tween := create_tween()
+	var tween: Tween = create_tween()
 	tween.tween_property(node, "modulate:a", 1.0, 0.35).set_ease(Tween.EASE_IN)
 
 # Display tower
@@ -1353,14 +1357,20 @@ func _orient_to_path(domino: Node2D, path_num: int) -> void:
 # Animate a domino sliding to its target position, with optional flip.
 # Per D-01/D-04: slide is 0.3s ease-out, flip is 0.2s parallel with slide.
 # Per D-06: caller must await this function before advancing turn.
-func _animate_placement(domino: Node2D, target_pos: Vector2, flip: bool) -> void:
-	var tween := create_tween()
+func _animate_placement(domino: Node2D, target_pos: Vector2, flip: bool, target_rotation: float = -999.0) -> void:
+	# Kill any active rearrange tween to prevent position/global_position conflicts
+	if domino.has_meta("_rearrange_tween"):
+		var old_tween = domino.get_meta("_rearrange_tween")
+		if old_tween and old_tween.is_valid():
+			old_tween.kill()
+		domino.remove_meta("_rearrange_tween")
+	var tween: Tween = create_tween()
+	tween.set_parallel(true)
+	tween.tween_property(domino, "global_position", target_pos, 0.3).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_QUAD)
+	if target_rotation != -999.0:
+		tween.tween_property(domino, "rotation", target_rotation, 0.3).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_QUAD)
 	if flip:
-		tween.set_parallel(true)
 		tween.tween_property(domino.get_node("Sprite2D"), "rotation_degrees", 180.0, 0.2)
-		tween.tween_property(domino, "global_position", target_pos, 0.3).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_QUAD)
-	else:
-		tween.tween_property(domino, "global_position", target_pos, 0.3).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_QUAD)
 	await tween.finished
 
 func _verify_anchors_ready():

--- a/Scenes/Level_4_DominoWorld/DominoWorld.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.gd
@@ -470,7 +470,8 @@ func rearrange_hand() -> void:
 	var hand_center_x: float = -192.0
 	for i in range(hand_count):
 		var new_pos := Vector2(hand_center_x + (i * HAND_SPACING) - (total_width / 2.0), 175)
-		unplaced[i].position = new_pos
+		var tween := unplaced[i].create_tween()
+		tween.tween_property(unplaced[i], "position", new_pos, 0.2).set_ease(Tween.EASE_OUT)
 		unplaced[i].original_pos = new_pos
 
 # path set-up
@@ -572,15 +573,14 @@ func place_domino(num):
 
 		# Force the domino to initialize correctly so the texture syncs with math
 		selected_domino.init(true_top, true_bot, top_el, bot_el, false)
-		if flip:
-			selected_domino.get_node("Sprite2D").rotation_degrees = 180
-		else:
-			selected_domino.get_node("Sprite2D").rotation_degrees = 0
 
-		# Place locally
+		# Place locally — animate slide (and flip if needed) before advancing turn
 		selected_domino.mark_as_placed(PLACED_SCALE)
-		selected_domino.global_position = _path_position_for_step(num, path_step_count[num])
+		var target_pos = _path_position_for_step(num, path_step_count[num])
+		# Set orientation immediately (path angle rotation)
 		_orient_to_path(selected_domino, num)
+		# Per D-01, D-04, D-06: animate slide (and flip if needed) before advancing turn
+		await _animate_placement(selected_domino, target_pos, flip)
 
 		# Update path ends
 		if flip:
@@ -793,23 +793,34 @@ func display_footprint_tile(round_num: int, footprint_num: int) -> void:
 	var domino = Domino.instantiate()
 	add_child(domino)
 	domino.scale = PLACED_SCALE
-	domino.global_position = _path_position_for_step(path_num, path_step_count[path_num])
-	_orient_to_path(domino, path_num)
 
 	var domino_title = str(top_n) + str(bot_n)
 	domino.get_node("Sprite2D").texture = load(ReferenceManager.get_reference("dominos/" + domino_title + ".png"))
 	domino.init(top_n, bot_n, top_e, bot_e, true)
 	domino.mark_as_placed(PLACED_SCALE)
 
-	# Flawless Flip logic
+	# Per D-02: remote domino slides from placing player's Character Bubble
+	var player_idx = turn  # turn holds the placing player's index at RPC receipt time
+	var bubble_name := "Character Bubble" + str(player_idx + 1)
+	var bubble := get_node_or_null(bubble_name)
+	if bubble:
+		domino.global_position = bubble.global_position
+	else:
+		domino.global_position = _path_position_for_step(path_num, path_step_count[path_num])
+	var target_pos = _path_position_for_step(path_num, path_step_count[path_num])
+	_orient_to_path(domino, path_num)
+
+	# Flawless Flip logic — path_ends and top_element set before animation
 	if flip:
-		domino.get_node("Sprite2D").rotation_degrees = 180
 		path_ends[path_num] = bot_n
 		domino.top_element = bot_e
 	else:
-		domino.get_node("Sprite2D").rotation_degrees = 0
 		path_ends[path_num] = top_n
 		domino.top_element = top_e
+
+	# Animate slide (and flip if needed) — no await since turn advancement
+	# is controlled by the host, not by this RPC handler
+	_animate_placement(domino, target_pos, flip)
 
 	end_dominos[path_num] = domino
 	path_step_count[path_num] += 1
@@ -1082,7 +1093,10 @@ func _execute_cpu_turn_async(cpu_id):
 			
 		rpc("update_domino_path", [true_bot, true_top], [bot_e, top_e], position_table[move.path_idx], move.path_idx, flip)
 		update_domino_path([true_bot, true_top], [bot_e, top_e], position_table[move.path_idx], move.path_idx, flip)
-		
+
+		# Per D-03: wait for slide animation to complete before continuing
+		await get_tree().create_timer(0.35).timeout
+
 		# POPUP PAUSE LOGIC
 		while $AlloyPopup.visible or $FootprintTilePopup.visible or $WellnessBeadPopup.visible:
 			await get_tree().process_frame
@@ -1315,6 +1329,19 @@ func _path_position_for_step(path_num: int, step_index: int) -> Vector2:
 # Optional: make the domino visually point along its growth direction
 func _orient_to_path(domino: Node2D, path_num: int) -> void:
 	domino.rotation = deg_to_rad(PATH_ANGLE_DEGREES[path_num] + ROTATION_OFFSET_DEG)
+
+# Animate a domino sliding to its target position, with optional flip.
+# Per D-01/D-04: slide is 0.3s ease-out, flip is 0.2s parallel with slide.
+# Per D-06: caller must await this function before advancing turn.
+func _animate_placement(domino: Node2D, target_pos: Vector2, flip: bool) -> void:
+	var tween := create_tween()
+	if flip:
+		tween.set_parallel(true)
+		tween.tween_property(domino.get_node("Sprite2D"), "rotation_degrees", 180.0, 0.2)
+		tween.tween_property(domino, "global_position", target_pos, 0.3).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_QUAD)
+	else:
+		tween.tween_property(domino, "global_position", target_pos, 0.3).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_QUAD)
+	await tween.finished
 
 func _verify_anchors_ready():
 	if position_table.size() != 8:

--- a/Scenes/Level_4_DominoWorld/DominoWorld.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.gd
@@ -45,6 +45,7 @@ var all_player_hands = {}  # Host tracks ALL player hands (human + CPU) for stal
 var _consecutive_help_count := 0  # Tracks consecutive Help presses without a placement
 var _round_advancing := false  # Re-entrancy guard for next_round() (Bug 3 fix)
 var _stalemate_in_progress := false  # Prevents multiple stalemate triggers per round
+var _game_over := false  # Stops all turn processing after final round
 
 # (Fall 2025) added variables
 var can_place = true # to check if currently selected domino is a double
@@ -523,6 +524,8 @@ func select_domino(domino) -> bool:
 
 # handles placing of domino onto a path
 func place_domino(num):
+	if _game_over:
+		return
 	_verify_anchors_ready()
 	var flip = false
 	if turn != self_num or !selected_domino:
@@ -898,6 +901,7 @@ func replace_domino():
 
 	# if we've completed round 9, end game
 	if center_num >= 9:
+		_game_over = true
 		add_tower(center_num + 1)
 		turn_label.text = "Game\nOver!"
 		end_label.text = "Winner: " + determine_winner() + "\n(Hover over faces to see stats.)"
@@ -1048,6 +1052,8 @@ func _trigger_stalemate() -> void:
 	_update_turn_label()
 
 @rpc("any_peer") func advance_turn():
+	if _game_over:
+		return
 	turn = (turn + 1) % len(gamestate.players)
 	_update_turn_label()
 	if multiplayer.is_server() and _check_stalemate():
@@ -1069,13 +1075,14 @@ func _update_turn_label():
 
 
 	# CPU TURN AUTOMATION (HOST ONLY)
-	if str(current_name).contains("CPU") and multiplayer.is_server():
+	if not _game_over and str(current_name).contains("CPU") and multiplayer.is_server():
 		_execute_cpu_turn_async(current_player_id)
 
 # The async function handles the CPU playing the domino
 func _execute_cpu_turn_async(cpu_id):
-	await get_tree().create_timer(1.5).timeout 
-	if sorted_players[turn] != cpu_id: return 
+	await get_tree().create_timer(1.5).timeout
+	if _game_over: return
+	if sorted_players[turn] != cpu_id: return
 	
 	var move = calculate_cpu_move(cpu_id)
 	var my_path_idx = sorted_players.find(cpu_id)
@@ -1145,6 +1152,8 @@ func _execute_cpu_turn_async(cpu_id):
 
 # handle when next round button pressed by host
 func _on_Next_pressed() -> void:
+	if _game_over:
+		return
 	# reset field for host
 	next_round()
 	can_place = true

--- a/Scenes/Level_4_DominoWorld/DominoWorld.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.gd
@@ -343,7 +343,7 @@ func _on_Start_pressed() -> void:
 		SaveManager.Save["0"].Current_Round = 0
 	
 	randomize_turn()
-		
+	
 	setup_dominos()
 	start_button.queue_free()
 	
@@ -548,6 +548,7 @@ func place_domino(num):
 		
 		# CRASH FIX: First domino of the round has no end_dominos[num] yet!
 		if end_dominos[num] == null:
+			rpc("change_path_collision", num, true)
 			if true_bot != path_ends[num]:
 				flip = true
 		else:
@@ -889,6 +890,10 @@ func replace_domino():
 	# show all footprint tiles from this round
 	footprint_tile_ring.show_round(center_num)
 	
+	# Re-enable all paths' collision
+	for i in range(8):
+		change_path_collision(i, false)
+	
 	# remove all old dominos from screen
 	num_placed = 0
 	_consecutive_help_count = 0
@@ -1078,6 +1083,20 @@ func _update_turn_label():
 	if not _game_over and str(current_name).contains("CPU") and multiplayer.is_server():
 		_execute_cpu_turn_async(current_player_id)
 
+
+@rpc("any_peer", "call_local", "reliable")
+func change_path_collision(index: int, is_disabled: bool) -> void:
+	var path: Sprite2D
+	if index < 6:
+		path = world_elements.get_node("Path" + str(index + 1))
+	elif index == 6:
+		path = world_elements.get_node("SunrisePath")
+	elif index == 7:
+		path = world_elements.get_node("SunsetPath")
+	if index != null:
+		path.disable(is_disabled)
+
+
 # The async function handles the CPU playing the domino
 func _execute_cpu_turn_async(cpu_id):
 	await get_tree().create_timer(1.5).timeout
@@ -1098,6 +1117,7 @@ func _execute_cpu_turn_async(cpu_id):
 		
 		# CRASH FIX: First piece of the round
 		if end_dominos[move.path_idx] == null:
+			rpc("change_path_collision", move.path_idx, true)
 			if true_bot != path_ends[move.path_idx]:
 				flip = true
 		else:

--- a/Scenes/Level_4_DominoWorld/DominoWorld.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.gd
@@ -568,9 +568,16 @@ func place_domino(num):
 		# Capture reference before await — selected_domino can become null during yield
 		var placed_domino = selected_domino
 
+		# Bug 1 fix: save global_position before reparenting — reparenting changes it
+		var saved_global_pos = placed_domino.global_position
+
 		# Reparent from UIElements to WorldElements before animating (D-20 pattern)
 		ui_elements.remove_child(placed_domino)
 		world_elements.add_child(placed_domino)
+
+		# Bug 1 fix: restore the hand position so animation starts from correct origin
+		placed_domino.global_position = saved_global_pos
+
 		placed_domino.mark_as_placed(PLACED_SCALE)
 		var target_pos = _path_position_for_step(num, path_step_count[num])
 		var target_rot = deg_to_rad(PATH_ANGLE_DEGREES[num] + ROTATION_OFFSET_DEG)

--- a/Scenes/Level_4_DominoWorld/DominoWorld.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.gd
@@ -346,7 +346,7 @@ func _on_Start_pressed() -> void:
 	setup_dominos()
 	start_button.queue_free()
 	
-	if (self_num == 0):
+	if multiplayer.is_server():
 		next_button.visible = true
 		
 	SFXController.playSFX(ReferenceManager.get_reference("next.wav"))
@@ -580,17 +580,18 @@ func place_domino(num):
 		# Capture reference before await — selected_domino can become null during yield
 		var placed_domino = selected_domino
 
-		# Bug 1 fix: UIElements is a CanvasLayer (screen coords), WorldElements uses world coords.
-		# Save screen position before reparenting, then convert to world coords after.
-		var screen_pos = placed_domino.global_position
+		# Bug 1 fix: UIElements is a CanvasLayer with scale 0.5 — global_position inside it
+		# is in the CanvasLayer's scaled coordinate space, NOT true viewport pixels.
+		# get_global_transform_with_canvas().origin gives the actual viewport position.
+		var viewport_pos = placed_domino.get_global_transform_with_canvas().origin
 
 		# Reparent from UIElements to WorldElements before animating (D-20 pattern)
 		ui_elements.remove_child(placed_domino)
 		world_elements.add_child(placed_domino)
 
-		# Bug 1 fix: convert screen coords → world coords using the canvas transform
-		# (which includes Camera2D offset/zoom for the default canvas layer)
-		placed_domino.global_position = placed_domino.get_canvas_transform().affine_inverse() * screen_pos
+		# Convert viewport position → world position using WorldElements' canvas transform
+		# (which includes Camera2D offset/zoom)
+		placed_domino.global_position = placed_domino.get_canvas_transform().affine_inverse() * viewport_pos
 
 		placed_domino.mark_as_placed(PLACED_SCALE)
 		var target_pos = _path_position_for_step(num, path_step_count[num])

--- a/Scenes/Level_4_DominoWorld/DominoWorld.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.gd
@@ -459,7 +459,7 @@ func rearrange_hand() -> void:
 	var all_nodes = get_tree().get_nodes_in_group("dominos")
 	var unplaced: Array = []
 	for domino in all_nodes:
-		if not domino.placed:
+		if not domino.placed and domino.get_parent() == ui_elements:
 			unplaced.append(domino)
 	# Sort left to right by current x-position to preserve ordering
 	unplaced.sort_custom(func(a, b): return a.position.x < b.position.x)
@@ -469,6 +469,11 @@ func rearrange_hand() -> void:
 	var total_width: float = (hand_count - 1) * HAND_SPACING
 	for i in range(hand_count):
 		var new_pos := Vector2(HAND_CENTER_X + (i * HAND_SPACING) - (total_width / 2.0), HAND_CENTER_Y)
+		# Bug 2 fix: kill any existing rearrange tween before creating a new one
+		if unplaced[i].has_meta("_rearrange_tween"):
+			var old_tw = unplaced[i].get_meta("_rearrange_tween")
+			if old_tw and old_tw.is_valid():
+				old_tw.kill()
 		var tween: Tween = create_tween()
 		tween.tween_property(unplaced[i], "position", new_pos, 0.2).set_ease(Tween.EASE_OUT)
 		unplaced[i].set_meta("_rearrange_tween", tween)
@@ -545,6 +550,10 @@ func place_domino(num):
 			if true_bot != path_ends[num] or (true_top == path_ends[num] and top_el != end_dominos[num].top_element):
 				flip = true
 			
+		# Bug 4 fix: doubles look identical when flipped — skip visual animation
+		# but keep internal flip state for element tracking (alloy/footprint checks)
+		var visual_flip = flip and (true_top != true_bot)
+
 		# Check for alloy
 		var touching_el = top_el if flip else bot_el
 		if end_dominos[num] != null and end_dominos[num].top_element != touching_el:
@@ -584,7 +593,7 @@ func place_domino(num):
 		var target_pos = _path_position_for_step(num, path_step_count[num])
 		var target_rot = deg_to_rad(PATH_ANGLE_DEGREES[num] + ROTATION_OFFSET_DEG)
 		camera.set_drag(false)
-		await _animate_placement(placed_domino, target_pos, flip, target_rot)
+		await _animate_placement(placed_domino, target_pos, visual_flip, target_rot)
 
 		# Update path ends
 		if flip:

--- a/Scenes/Level_4_DominoWorld/DominoWorld.tscn
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.tscn
@@ -1082,6 +1082,43 @@ theme_override_styles/pressed = SubResource("21")
 theme_override_styles/hover = SubResource("19")
 metadata/_edit_lock_ = true
 
+[node name="StalematePopup" type="Popup" parent="." unique_id=1500000001]
+position = Vector2i(303, 75)
+size = Vector2i(417, 250)
+visible = false
+
+[node name="Title" type="Label" parent="StalematePopup" unique_id=1500000002]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 40.0
+offset_top = 30.0
+offset_right = -40.0
+offset_bottom = -170.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 4
+theme_override_fonts/font = SubResource("6")
+text = "Round Over - Stalemate!"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Info" type="Label" parent="StalematePopup" unique_id=1500000003]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 40.0
+offset_top = 100.0
+offset_right = -40.0
+offset_bottom = -30.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_fonts/font = SubResource("7")
+text = "No player has a valid move.
+Advancing to next round..."
+autowrap_mode = 3
+horizontal_alignment = 1
+
 [connection signal="pressed" from="AlloyPopup/Close" to="." method="_close_Alloy_popup"]
 [connection signal="pressed" from="WellnessBeadPopup/Close" to="." method="_close_WellnessBead_popup"]
 [connection signal="pressed" from="FootprintTilePopup/Close" to="." method="_close_FootprintTile_popup"]

--- a/Scenes/Level_4_DominoWorld/DominoWorld.tscn
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Texture2D" uid="uid://c7thnwhpiw6xc" path="res://UI/sprites/reference.png" id="1"]
 [ext_resource type="PackedScene" uid="uid://crx57hj081ag0" path="res://Scenes/Components/Character Bubble.tscn" id="3"]
-[ext_resource type="Script" uid="uid://4dmvtajf87yc" path="res://Scenes/Level_4_DominoWorld/camera_2d.gd" id="3_0lvn3"]
+[ext_resource type="Script" path="res://Scenes/Level_4_DominoWorld/camera_2d.gd" id="3_0lvn3"]
 [ext_resource type="Texture2D" uid="uid://belf0op6o2ek2" path="res://UI/sprites/character_sprites/faces/0.png" id="4"]
 [ext_resource type="Texture2D" uid="uid://ftttl40wh16g" path="res://UI/sprites/character_sprites/faces/2.png" id="5"]
 [ext_resource type="PackedScene" uid="uid://cixonnslrnkt" path="res://Scenes/Core/Settings.tscn" id="6"]
@@ -351,27 +351,24 @@ z_index = -1
 position = Vector2(-114, -174)
 scale = Vector2(0.4, 0.4)
 
-[node name="face" parent="WorldElements/Character Bubble1" index="0" unique_id=707796254]
+[node name="Score" parent="WorldElements/Character Bubble1" index="0" unique_id=1386002985]
+z_index = 2
+
+[node name="face" parent="WorldElements/Character Bubble1" index="1" unique_id=707796254]
 position = Vector2(-60.9, 35)
 
-[node name="front_hair" parent="WorldElements/Character Bubble1" index="1" unique_id=633581683]
+[node name="front_hair" parent="WorldElements/Character Bubble1" index="2" unique_id=633581683]
 position = Vector2(-60.9, 130)
 
-[node name="back_hair" parent="WorldElements/Character Bubble1" index="2" unique_id=1771050701]
+[node name="back_hair" parent="WorldElements/Character Bubble1" index="3" unique_id=1771050701]
 position = Vector2(-60.9, 130)
 texture = ExtResource("13")
 
-[node name="Area2D" parent="WorldElements/Character Bubble1" index="3" unique_id=1953206665]
+[node name="Area2D" parent="WorldElements/Character Bubble1" index="4" unique_id=1953206665]
 position = Vector2(39.099995, -79.99999)
 
 [node name="CollisionShape2D" parent="WorldElements/Character Bubble1/Area2D" index="0" unique_id=1168569297]
 position = Vector2(-100, 115)
-
-[node name="Score" parent="WorldElements/Character Bubble1" index="4" unique_id=1386002985]
-z_index = 2
-
-[node name="Popup" parent="WorldElements/Character Bubble1/Score/Button" index="2"]
-position = Vector2i(0, 0)
 
 [node name="Character Bubble2" parent="WorldElements" unique_id=917609711 instance=ExtResource("3")]
 z_index = -1
@@ -898,10 +895,35 @@ position = Vector2(-528, -304)
 custom_minimum_size = Vector2(0, 950)
 layout_mode = 2
 
+[node name="BottomPanel" type="HBoxContainer" parent="UIElements/HUD" unique_id=701637445]
+custom_minimum_size = Vector2(0, 51)
+layout_mode = 2
+alignment = 1
+
+[node name="Start" parent="UIElements/HUD/BottomPanel" unique_id=1793244429 instance=ExtResource("14_gq41l")]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+text = "Start"
+font_color = Color(0, 0.6862745, 0, 1)
+border_color = Color(0, 0.6862745, 0, 1)
+
+[node name="Help" parent="UIElements/HUD/BottomPanel" unique_id=93144388 instance=ExtResource("14_gq41l")]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+text = "Need Help"
+font_color = Color(1, 0.48235294, 0, 1)
+border_color = Color(1, 0.48235294, 0, 1)
+
+[node name="Reset" parent="UIElements/HUD/BottomPanel" unique_id=697829354 instance=ExtResource("14_gq41l")]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+text = "Reset"
+font_color = Color(0, 0.6862745, 0, 1)
+border_color = Color(0, 0.6862745, 0, 1)
+
 [node name="StalematePopup" type="Popup" parent="UIElements" unique_id=1500000001]
 position = Vector2i(303, 75)
 size = Vector2i(417, 250)
-visible = false
 
 [node name="Title" type="Label" parent="UIElements/StalematePopup" unique_id=1500000002]
 anchors_preset = 15
@@ -932,34 +954,8 @@ grow_vertical = 2
 theme_override_fonts/font = SubResource("7")
 text = "No player has a valid move.
 Advancing to next round..."
-autowrap_mode = 3
 horizontal_alignment = 1
-
-[node name="BottomPanel" type="HBoxContainer" parent="UIElements/HUD" unique_id=701637445]
-custom_minimum_size = Vector2(0, 51)
-layout_mode = 2
-alignment = 1
-
-[node name="Start" parent="UIElements/HUD/BottomPanel" unique_id=1793244429 instance=ExtResource("14_gq41l")]
-custom_minimum_size = Vector2(200, 0)
-layout_mode = 2
-text = "Start"
-font_color = Color(0, 0.6862745, 0, 1)
-border_color = Color(0, 0.6862745, 0, 1)
-
-[node name="Help" parent="UIElements/HUD/BottomPanel" unique_id=93144388 instance=ExtResource("14_gq41l")]
-custom_minimum_size = Vector2(200, 0)
-layout_mode = 2
-text = "Need Help"
-font_color = Color(1, 0.48235294, 0, 1)
-border_color = Color(1, 0.48235294, 0, 1)
-
-[node name="Reset" parent="UIElements/HUD/BottomPanel" unique_id=697829354 instance=ExtResource("14_gq41l")]
-custom_minimum_size = Vector2(200, 0)
-layout_mode = 2
-text = "Reset"
-font_color = Color(0, 0.6862745, 0, 1)
-border_color = Color(0, 0.6862745, 0, 1)
+autowrap_mode = 3
 
 [node name="Place" type="AudioStreamPlayer" parent="UIElements" unique_id=594223884]
 stream = ExtResource("12")

--- a/Scenes/Level_4_DominoWorld/DominoWorldTutorial.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorldTutorial.gd
@@ -167,9 +167,14 @@ func setup_dominos():
 
 # initialize 7 dominos from main deck on player's screen
 func draw_7():
+	var my_id = get_tree().get_unique_id()
+	if not all_player_hands.has(my_id):
+		all_player_hands[my_id] = []
 	for i in range(9):
 		# get domino info
 		var domino_nums = draw_domino()
+		# Track hand numerically for stalemate detection (D-25)
+		all_player_hands[my_id].append([domino_nums[0], domino_nums[1]])
 		var domino = Domino.instantiate()
 		var domino_title = str(domino_nums[1]) + str(domino_nums[0])
 		domino.get_node("Sprite2D").texture = load(ReferenceManager.get_reference("dominos/" + domino_title + ".png"))
@@ -290,9 +295,24 @@ func place_domino(num):
 			num_placed += 1
 			_consecutive_help_count = 0
 
+			# Update all_player_hands: remove placed domino from tracker (D-25)
+			var placing_pid = sorted_players[self_num]
+			if all_player_hands.has(placing_pid):
+				for i in range(all_player_hands[placing_pid].size()):
+					var h = all_player_hands[placing_pid][i]
+					if (h[0] == selected_domino.top_num and h[1] == selected_domino.bottom_num) \
+					or (h[0] == selected_domino.bottom_num and h[1] == selected_domino.top_num):
+						all_player_hands[placing_pid].remove_at(i)
+						break
+
 			turn = (turn + 1) % len(gamestate.players)
 			if not _stalemate_active:
 				$Turn.text = gamestate.players[sorted_players[turn]] + "'s\nTurn"
+
+			# True stalemate check after turn advancement (D-25)
+			if _check_stalemate():
+				_trigger_stalemate()
+				return
 
 			# if helped another player on their path, get a wellness bead
 			if num < 6 and get_node("Path3D" + str(num + 1)).temp == true:
@@ -599,6 +619,10 @@ func _on_Help_pressed() -> void:
 		SFXController.playSFX(ReferenceManager.get_reference("next.wav"))
 		# Per D-15: behavioral stalemate — all players pressed Help in one rotation
 		if _consecutive_help_count >= len(sorted_players):
+			_trigger_stalemate()
+			return
+		# True stalemate check after Help turn advance (D-25)
+		if _check_stalemate():
 			_trigger_stalemate()
 
 # add player's path denoted by num to all player's screens

--- a/Scenes/Level_4_DominoWorld/DominoWorldTutorial.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorldTutorial.gd
@@ -20,6 +20,11 @@ var selected_domino = null  # currently selected domino
 var center_num = 0  # current round number
 var num_placed = 0
 
+# Stalemate detection (per D-15: mirrors DominoWorld.gd, simplified for single-player)
+var all_player_hands = {}
+var _consecutive_help_count := 0
+var _stalemate_active := false  # Guards $Turn label during stalemate display
+
 var path_ends = [0, 0, 0, 0, 0, 0, 0, 0]  # last number on domino chain in each path
 var end_dominos = [null, null, null, null, null, null, null, null]  # last domino on domino chain in each path
 
@@ -283,9 +288,11 @@ func place_domino(num):
 			placed_domino_offset[num] = placed_domino_offset[num] + Vector2(160, -176)
 
 			num_placed += 1
+			_consecutive_help_count = 0
 
 			turn = (turn + 1) % len(gamestate.players)
-			$Turn.text = gamestate.players[sorted_players[turn]] + "'s\nTurn"
+			if not _stalemate_active:
+				$Turn.text = gamestate.players[sorted_players[turn]] + "'s\nTurn"
 
 			# if helped another player on their path, get a wellness bead
 			if num < 6 and get_node("Path3D" + str(num + 1)).temp == true:
@@ -410,7 +417,8 @@ func display_footprint_tile(round_num: int, footprint_num: int) -> void:
 
 	# change turn
 	turn = (turn + 1) % len(gamestate.players)
-	$Turn.text = gamestate.players[sorted_players[turn]] + "'s\nTurn"
+	if not _stalemate_active:
+		$Turn.text = gamestate.players[sorted_players[turn]] + "'s\nTurn"
 
 
 # replace placed domino with one from the deck
@@ -440,8 +448,11 @@ func replace_domino():
 	
 	# remove all old dominos from screen
 	num_placed = 0
+	_consecutive_help_count = 0
+	_stalemate_active = false
+	all_player_hands.clear()
 	placed_domino_offset = [Vector2(0, 0), Vector2(0, 0), Vector2(0, 0),
-							Vector2(0, 0), Vector2(0, 0), Vector2(0, 0), 
+							Vector2(0, 0), Vector2(0, 0), Vector2(0, 0),
 							Vector2(0, 0), Vector2(0, 0)]
 	var group_dominos = get_tree().get_nodes_in_group("dominos")
 	clear_selected_domino()
@@ -541,20 +552,60 @@ func add_tower(round_num):
 	elif round_num == 10:
 		$Tower/Sprite2D/Diamond.visible = true
 
+# True stalemate check: returns true if NO player has ANY valid move on ANY accessible path
+# Tutorial is single-player only — no multiplayer.is_server() guard needed
+# Falls back gracefully if all_player_hands is not populated (returns false = no stalemate)
+func _check_stalemate() -> bool:
+	for idx in range(sorted_players.size()):
+		var pid = sorted_players[idx]
+		var player_hand = []
+		if all_player_hands.has(pid):
+			player_hand = all_player_hands[pid]
+		else:
+			return false
+		if player_hand.size() == 0:
+			continue
+		for domino_pair in player_hand:
+			if domino_pair[0] == path_ends[idx] or domino_pair[1] == path_ends[idx]:
+				return false
+			for p_idx in range(6):
+				if p_idx != idx and get_node_or_null("Path3D" + str(p_idx + 1)) and get_node("Path3D" + str(p_idx + 1)).visible:
+					if domino_pair[0] == path_ends[p_idx] or domino_pair[1] == path_ends[p_idx]:
+						return false
+			for sun_idx in [6, 7]:
+				if domino_pair[0] == path_ends[sun_idx] or domino_pair[1] == path_ends[sun_idx]:
+					return false
+	return true
+
+# Stalemate trigger (simplified — no RPC, tutorial is single-player)
+# Uses _stalemate_active flag to prevent $Turn label overwrite during 3s display
+func _trigger_stalemate() -> void:
+	_stalemate_active = true
+	$Turn.text = "Stalemate!\nNext Round..."
+	await get_tree().create_timer(3.0).timeout
+	_stalemate_active = false
+	_on_Next_pressed()
+
 # if player cannot play a domino on their paths
 func _on_Help_pressed() -> void:
 	if turn == self_num:
+		_consecutive_help_count += 1
 		# add their path to everyone else's screen
 		rpc("add_path", self_num + 1)
 		# change turn
 		turn = (turn + 1) % len(gamestate.players)
-		$Turn.text = gamestate.players[sorted_players[turn]] + "'s\nTurn"
+		if not _stalemate_active:
+			$Turn.text = gamestate.players[sorted_players[turn]] + "'s\nTurn"
 		SFXController.playSFX(ReferenceManager.get_reference("next.wav"))
+		# Per D-15: behavioral stalemate — all players pressed Help in one rotation
+		if _consecutive_help_count >= len(sorted_players):
+			_trigger_stalemate()
 
 # add player's path denoted by num to all player's screens
 @rpc("any_peer") func add_path(num):
 	turn = (turn + 1) % len(gamestate.players)
-	$Turn.text = gamestate.players[sorted_players[turn]] + "'s\nTurn"
+	if not _stalemate_active:
+		$Turn.text = gamestate.players[sorted_players[turn]] + "'s\nTurn"
 	get_node("Path3D" + str(num)).visible = true
 
 # remove player's path denoted by num from all player's screens

--- a/test/unit/DominoWorldStalemateTest.gd
+++ b/test/unit/DominoWorldStalemateTest.gd
@@ -1,0 +1,91 @@
+# GdUnit generated TestSuite
+#warning-ignore-all:unused_argument
+#warning-ignore-all:return_value_discarded
+class_name DominoWorldStalemateTest
+extends GdUnitTestSuite
+
+# TestSuite for stalemate detection logic in DominoWorld.gd
+# Tests cover _check_stalemate() and _consecutive_help_count behavior
+# These tests are RED (failing) until Plan 01-01 implements the logic.
+
+const __source = "res://Scenes/Level_4_DominoWorld/DominoWorld.gd"
+const __prefab_source = "res://Scenes/Level_4_DominoWorld/DominoWorld.tscn"
+
+# NOTE: DominoWorld has complex multiplayer and autoload dependencies.
+# Tests instantiate the script directly when possible to avoid scene-level
+# dependency issues, falling back to state-variable inspection.
+
+
+# Test 1: _check_stalemate returns true when no valid moves exist
+# Sets up a single-player scenario where the player's domino cannot match any path end.
+func test_check_stalemate_returns_true_when_no_valid_moves() -> void:
+	var dw = load(__source).new()
+	auto_free(dw)
+
+	# Single player with id 1
+	dw.sorted_players = [1]
+	# Personal path ends at 5 (index 0)
+	dw.path_ends = [5, 0, 0, 0, 0, 0, 0, 0]
+	# Player has domino 3-4 — no match for 5
+	dw.all_player_hands = {1: [[3, 4]]}
+	dw.cpu_hands = {}
+	# No trains open
+	dw.train_open = [false, false, false, false, false, false, false, false]
+
+	var result = dw._check_stalemate()
+	assert_bool(result).is_true()
+
+
+# Test 2: _check_stalemate returns false when the player has a valid move
+# Player holds a domino that matches their personal path end.
+func test_check_stalemate_returns_false_when_player_has_valid_move() -> void:
+	var dw = load(__source).new()
+	auto_free(dw)
+
+	dw.sorted_players = [1]
+	dw.path_ends = [5, 0, 0, 0, 0, 0, 0, 0]
+	# Player has domino 5-3 — matches path_end 5
+	dw.all_player_hands = {1: [[5, 3]]}
+	dw.cpu_hands = {}
+	dw.train_open = [false, false, false, false, false, false, false, false]
+
+	var result = dw._check_stalemate()
+	assert_bool(result).is_false()
+
+
+# Test 3: _check_stalemate considers open trains
+# Neither player matches their own path, but if an open train matches a held domino
+# then a move is available — stalemate is false.
+func test_check_stalemate_returns_false_when_open_train_available() -> void:
+	var dw = load(__source).new()
+	auto_free(dw)
+
+	dw.sorted_players = [1, 2]
+	# Path index 0 -> player 1 ends at 5, path index 1 -> player 2 ends at 7
+	dw.path_ends = [5, 7, 0, 0, 0, 0, 0, 0]
+	# Both players hold dominoes that don't match their own paths
+	dw.all_player_hands = {1: [[3, 4]], 2: [[3, 4]]}
+	dw.cpu_hands = {}
+	# Player 2's train is open (index 1)
+	dw.train_open = [false, true, false, false, false, false, false, false]
+
+	# Neither player holds a domino matching path_end 5 or 7 — should be stalemate
+	var result_stalemate = dw._check_stalemate()
+	assert_bool(result_stalemate).is_true()
+
+	# Now give player 1 a domino matching the open train end (7)
+	dw.all_player_hands = {1: [[7, 2]], 2: [[3, 4]]}
+
+	# Player 1 can play on the open train — not a stalemate
+	var result_no_stalemate = dw._check_stalemate()
+	assert_bool(result_no_stalemate).is_false()
+
+
+# Test 4: _consecutive_help_count exists and initializes to 0
+# This is a state-variable presence check. The variable is added in Plan 01-01.
+func test_consecutive_help_count_exists() -> void:
+	var dw = load(__source).new()
+	auto_free(dw)
+
+	# _consecutive_help_count must exist and default to 0
+	assert_int(dw._consecutive_help_count).is_equal(0)

--- a/test/unit/DominoWorldStalemateTest.gd.uid
+++ b/test/unit/DominoWorldStalemateTest.gd.uid
@@ -1,0 +1,1 @@
+uid://ckgnkwq8wslui


### PR DESCRIPTION
  - Stalemate Detection (DEV-38): Detects when no player has a valid move, shows a Stalemate Popup, and tracks consecutive help counts.
  - Domino Animations (DEV-41): Adds placement slide animations, flip animations for non-double dominoes, hand rearrange tweens, and Character Bubble glow/round transition effects.
  - Bug Fixes (DEV-42): Fixes animation origin coordinates, glow arc centering, re-entrant double-advance on round transitions, global_position drift during reparenting, visual flip on doubles, and stops CPU turns/player actions after game over.
  - Tests: GdUnit4 unit tests for stalemate detection covering no-move, valid-move, and open-train scenarios.