### PR TITLE
DEV-47: Restart Domino Rounds at Round 0

### DIFF
--- a/Scenes/Level_4_DominoWorld/DominoWorld.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.gd
@@ -1195,6 +1195,7 @@ func _on_Reset_pressed() -> void:
 		rpc("sync_reset_game")
 
 @rpc("authority", "call_local") func sync_reset_game():
+	SaveManager.Save["0"].Current_Round = 0
 	get_tree().reload_current_scene()
 
 #intialize tower as not seen


### PR DESCRIPTION
savemanager was autoloading a singleton that persisted across all scene reloads. so the save always held value 9 and was never reset save data once pressing reset, Force Reset to round 0 whenever clicking reset. I think this entire function needs to be looked through but this should make the game playable again without having to fully reset the game.