### PR TITLE
DEV-45: Icon Select Visual Glitch

### DIFF
--- a/Autoloads/gamestate.gd
+++ b/Autoloads/gamestate.gd
@@ -183,7 +183,7 @@ func _connected_fail():
 	emit_signal("connection_failed")
 
 # Lobby management functions.
-@rpc("any_peer", "call_local") func register_player(new_player_name,cpunum):
+@rpc("any_peer", "call_local") func register_player(new_player_name, cpunum):
 	var id = multiplayer.get_remote_sender_id()
 	
 	if id == 0:
@@ -201,6 +201,8 @@ func _connected_fail():
 				rpc_id(id, "join_accepted")
 	
 	id += cpunum
+	if players.has(id):
+		return
 	var CharacterFound = false
 	players[id] = new_player_name
 	if(SaveManager.loaded_data):
@@ -305,8 +307,6 @@ func host_single_player(new_player_name):
 	# Set MAX_PEERS to 1 since it's singleplayer
 	peer.create_server(0, 1) 
 	multiplayer.multiplayer_peer = peer
-	
-	var id = multiplayer.get_unique_id()
 	rpc("register_player", player_name, 0)
 
 func host_game(new_player_name) -> Error:

--- a/Scenes/Components/PlayerIconButton.gd
+++ b/Scenes/Components/PlayerIconButton.gd
@@ -64,6 +64,7 @@ func _on_focus_exited():
 	if !disabled:
 		animate_background(DEFAULT_BACKGROUND_COLOR)
 
+
 func _update_border_colors():
 	if animated_style:
 		animated_style.border_color = border_color

--- a/Scenes/Core/Lobby.gd
+++ b/Scenes/Core/Lobby.gd
@@ -84,7 +84,7 @@ func _on_join_accepted():
 	var ip = $Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/HBoxContainer/Join/IP/MarginContainer/LineEdit.text
 	if ip.is_empty():
 		ip = str(local_ip)
-		
+	
 	waitroom_host_name.set_text("Host: ")
 	waitroom_host_ip.set_text("Host IP: " + ip)
 	
@@ -97,7 +97,15 @@ func _on_join_accepted():
 	refresh_lobby()
 	await get_tree().process_frame
 	
+	# Set icon
+	var player_id = multiplayer.get_unique_id()
+	if player_id in gamestate.player_icon:
+		selected_icon = gamestate.player_icon[player_id]
+		gamestate.player_icon.erase(player_id)
+	else:
+		pick_random_icon()
 	set_player_icon(selected_icon)
+	
 	_update_start_button_state()
 
 
@@ -133,10 +141,7 @@ func refresh_lobby():
 	for p in players:
 		var index = item_list.add_item(p)
 		item_list.set_item_tooltip(index, " ")
-
-	# Ensure Start button is visible and properly configured
 	_update_start_button_state()
-	
 	if multiplayer.is_server():
 		rpc("sync_all_icons", gamestate.player_icon)
 
@@ -166,13 +171,18 @@ func handle_level(level):
 		_on_game_error("Port already in use. Cannot host.")
 		return
 	
+	# Assign an icon
+	var player_id = multiplayer.get_unique_id()
+	if player_id in gamestate.player_icon:
+		selected_icon = gamestate.player_icon[player_id]
+		gamestate.player_icon.erase(player_id)
+	else:
+		pick_random_icon()
+	set_player_icon(selected_icon)
+	
 	change_menu_smoothly(LobbyContainer, WaitRoomContainer)
 	
 	await WaitRoomContainer.get_node("AnimationPlayer").animation_finished
-	await get_tree().process_frame
-	await get_tree().process_frame
-	
-	refresh_lobby()
 	await get_tree().process_frame
 	
 	_update_start_button_state()
@@ -223,7 +233,6 @@ func _update_start_button_state() -> void:
 func _on_icon_selected(icon_name: String) -> void:
 	selected_icon = icon_name
 	set_player_icon(icon_name)
-	_highlight_selected_icon()
 	SFXController.playSFX(ReferenceManager.get_reference("next.wav"))
 	_update_start_button_state()
 
@@ -232,13 +241,12 @@ func set_player_icon(icon_name: String):
 	var player_id = multiplayer.get_unique_id()
 	if player_id in gamestate.players:
 		gamestate.player_icon[player_id] = icon_name
-		_highlight_selected_icon()
-		# Sync with other players if multiplayer
 		if multiplayer.multiplayer_peer != null:
 			if multiplayer.is_server():
 				rpc("sync_player_icon", player_id, icon_name)
 			else:
 				rpc_id(1, "sync_player_icon", player_id, icon_name)
+	_highlight_selected_icon()
 
 
 @rpc("any_peer") func sync_player_icon(player_id: int, icon_name: String):
@@ -247,6 +255,11 @@ func set_player_icon(icon_name: String):
 		for peer in multiplayer.get_peers():
 			if peer != player_id: # Don't echo it back to the client who just sent it
 				rpc_id(peer, "sync_player_icon", player_id, icon_name)
+	_highlight_selected_icon()
+
+
+@rpc("any_peer", "call_local") func sync_all_icons(full_icon_dict: Dictionary):
+	gamestate.player_icon = full_icon_dict.duplicate()
 	_highlight_selected_icon()
 
 
@@ -263,6 +276,7 @@ func _highlight_selected_icon() -> void:
 			else:
 				button.set_is_available(true)
 		else:
+			button.set_is_available(true)
 			if !button.get_is_selected():
 				button.press()
 
@@ -274,19 +288,12 @@ func get_button_from_icon_name(icon_name: String) -> PlayerIconButton:
 	return null
 
 
-@rpc("any_peer", "call_local") func sync_all_icons(full_icon_dict: Dictionary):
-	# Update local dictionary to match the host
-	gamestate.player_icon = full_icon_dict
-	var my_id = multiplayer.get_unique_id()
-	
-	# If I haven't picked an icon yet, pick a random unique one
-	if not gamestate.player_icon.has(my_id):
-		var available = _get_available_icons()
-		if available.size() > 0:
-			selected_icon = available.pick_random()
-		else:
-			selected_icon = "basket.png"
-		set_player_icon(selected_icon)
+func pick_random_icon() -> void:
+	var available = _get_available_icons()
+	if available.size() > 0:
+		selected_icon = available.pick_random()
+	else:
+		selected_icon = "basket.png"
 
 
 func _get_available_icons() -> Array[String]:
@@ -331,5 +338,4 @@ func _on_Start_Button_pressed():
 	if selected_icon == null or selected_icon == "":
 		print("ERROR: Cannot start game - no icon selected!")
 		return
-	print("Start button pressed! Selected icon: ", selected_icon)
 	gamestate.begin_game()

--- a/Scenes/Core/Lobby.tscn
+++ b/Scenes/Core/Lobby.tscn
@@ -48,6 +48,9 @@ _data = {
 
 [sub_resource type="FontFile" id="8"]
 fallbacks = Array[Font]([ExtResource("6")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
 cache/0/variation_coordinates = {}
 cache/0/face_index = 0
 cache/0/embolden = 0.0
@@ -301,6 +304,9 @@ _data = {
 
 [sub_resource type="FontFile" id="12"]
 fallbacks = Array[Font]([ExtResource("6")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
 cache/0/variation_coordinates = {}
 cache/0/face_index = 0
 cache/0/embolden = 0.0
@@ -488,7 +494,7 @@ text = "Host"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="VSeparator" type="VSeparator" parent="Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/HBoxContainer"]
+[node name="VSeparator" type="VSeparator" parent="Lobby_Container/HBoxContainer/MenuContainer/Menu/VBoxContainer/HBoxContainer" unique_id=1525464109]
 layout_mode = 2
 theme_override_constants/separation = 20
 


### PR DESCRIPTION
There were a few edge cases for the icon select screen to account for. 
- `Host Creating Lobby`: Initially, when the host created the Domino lobby, no icons would be selected visually even though one was selected programmatically. This has been changed to ensure that the selected icon is shown immediately upon the lobby's creation. If the user's save data has a saved icon, then this icon is selected. Otherwise, a random icon is selected.
- `Client Joins Lobby`: Initially, when the client joined the lobby, the disabled buttons representing selected icons weren't always accurate. Now, whenever a new player joins the lobby, it causes a visual update for all users to ensure that icon buttons are consistent.
- `Client Leaves Lobby`: Initially, when a client leaved the lobby, the icon they had selected would remain disabled for the other users in the lobby until a user tried selecting another icon, forcing an update. Now, when a client leaves the lobby, it immediately triggers an update for all remaining users, ensuring icon buttons are always updated on time.