### PR TITLE
DEV-21: Handle Player Leaving

### DIFF
--- a/Autoloads/gamestate.gd
+++ b/Autoloads/gamestate.gd
@@ -150,7 +150,10 @@ signal connection_failed()
 signal game_ended()
 signal game_error(what)
 signal join_accepted_signal
+signal hot_join_accepted_signal
+
 var game_in_progress = false
+var is_hot_joining = false
 
 # Callback from SceneTree.
 func _player_connected(_id):
@@ -164,10 +167,29 @@ func _player_connected(_id):
 
 # Callback from SceneTree.
 func _player_disconnected(id):
-	if has_node("/root/World"): # Game is in progress.
-		if multiplayer.is_server():
-			emit_signal("game_error", "Player " + players[id] + " disconnected")
-			end_game()
+	if has_node("/root/Manager"): # Game is in progress.
+		if multiplayer.is_server() and players.has(id):
+			# Turn the dropped player into a CPU
+			var original_name = players[id]
+			if not str(original_name).contains("CPU"):
+				var cpu_name = original_name + " (CPU)"
+				
+				# Generate a protected negative integer ID so Native ENet doesn't recycle this ID onto a new player later!
+				var safe_cpu_id = -(id + 1000)
+				rpc("sync_player_id_change", id, safe_cpu_id, cpu_name)
+				
+				# Map CPU hands first BEFORE sending the RPC (so AI logic is ready)
+				var manager = get_node_or_null("/root/Manager")
+				if manager != null and "current_level" in manager:
+					var world = manager.current_level
+					if world != null:
+						if "all_player_hands" in world and world.all_player_hands.has(safe_cpu_id):
+							if "cpu_hands" in world:
+								# Give the CPU the human's remaining hand so it can play
+								world.cpu_hands[safe_cpu_id] = world.all_player_hands[safe_cpu_id].duplicate(true)
+						
+				# Now that the CPU is mapped, broadcast the name change which also triggers the turn label execution
+				rpc("update_player_name", safe_cpu_id, cpu_name)
 	else: # Game is not in progress.
 		# Unregister this player.
 		unregister_player(id)
@@ -189,16 +211,70 @@ func _connected_fail():
 	if id == 0:
 		id = multiplayer.get_unique_id()
 
+	# PREVENT GHOSTS: Clients should never blindly accept human registrations mid-game
+	# because the server might reject them, but the clients will never natively erase them!
+	# Mid-game human additions are ONLY handled securely by the server's explicit sync_player_id_change.
+	var is_cpu = str(new_player_name).contains("CPU")
+	if not multiplayer.is_server() and game_in_progress and not is_cpu:
+		return
+
+	var target_reclaim_id = -1
 	# --- Server Handshake Gatekeeper ---
 	if multiplayer.is_server():
-		# Check if the player is a CPU. If they are, let them bypass the lock!
-		if game_in_progress and not str(new_player_name).contains("CPU"):
-			if id != 1: # Don't kick the host!
-				rpc_id(id, "join_rejected", "Game already in progress!")
-			return # Abort registration completely!
-		else:
-			if id != 1 and not str(new_player_name).contains("CPU"):
-				rpc_id(id, "join_accepted")
+
+		# Shield existing human players from getting processed again during retro-active peer discoveries
+		if not is_cpu and players.has(id):
+			return
+			
+		if not is_cpu and id != 1:
+			var conflict = false
+			for p_id in players:
+				if p_id == id:
+					continue # Ignore self for duplicate name checks
+					
+				var active_name = str(players[p_id])
+				if active_name == str(new_player_name):
+					conflict = true
+					break
+				elif active_name == str(new_player_name) + " (CPU)":
+					target_reclaim_id = p_id
+					break
+			
+			if conflict:
+				rpc_id(id, "join_rejected", "Name already taken!")
+				return
+				
+			if game_in_progress:
+				if target_reclaim_id != -1:
+					# Swap the CPU's ID to this new client's ID so they can take over
+					rpc("sync_player_id_change", target_reclaim_id, id, new_player_name)
+					
+					var state_package = {
+						"players": players,
+						"player_icon": player_icon,
+						"lydia_lion": lydia_lion,
+						"alloys": alloys,
+						"footprint_tiles": footprint_tiles,
+						"wellness_beads": wellness_beads,
+						"elcitraps": elcitraps,
+					}
+					rpc_id(id, "push_full_gamestate", state_package)
+					return
+				else:
+					rpc_id(id, "join_rejected", "Game already in progress!")
+					return
+			else:
+				if target_reclaim_id != -1:
+					# Client reconnecting in the lobby
+					rpc("sync_player_id_change", target_reclaim_id, id, new_player_name)
+					rpc_id(id, "join_accepted")
+					return
+					
+			rpc_id(id, "join_accepted")
+		
+		# CPUs always bypass the lock
+		elif is_cpu:
+			pass
 	
 	id += cpunum
 	var CharacterFound = false
@@ -242,6 +318,46 @@ func unregister_player(id):
 	if player_icon.has(id):
 		player_icon.erase(id)
 	emit_signal("player_list_changed")
+
+@rpc("any_peer", "call_local") func update_player_name(id: int, new_name: String):
+	if players.has(id):
+		players[id] = new_name
+		emit_signal("player_list_changed")
+		
+		# Immediately refresh the turn label if the game is active, so clients see "(CPU)" appended mid-turn
+		if has_node("/root/Manager"):
+			var manager = get_node("/root/Manager")
+			if "current_level" in manager and manager.current_level != null:
+				if manager.current_level.has_method("_update_turn_label"):
+					manager.current_level._update_turn_label()
+
+@rpc("any_peer", "call_local", "reliable")
+func sync_player_id_change(old_id: int, new_id: int, new_name: String):
+	players[new_id] = new_name
+	if players.has(old_id): players.erase(old_id)
+	
+	for dict in [total_points, lydia_lion, alloys, footprint_tiles, wellness_beads, elcitraps, hair, clothes, body, player_icon]:
+		if dict.has(old_id):
+			dict[new_id] = dict[old_id]
+			dict.erase(old_id)
+			
+	emit_signal("player_list_changed")
+	
+	if has_node("/root/Manager"):
+		var manager = get_node("/root/Manager")
+		var world_node = null
+		if "current_level" in manager: world_node = manager.current_level
+		if world_node:
+			if world_node.get("cpu_hands") != null and world_node.cpu_hands.has(old_id):
+				world_node.cpu_hands.erase(old_id)
+			if world_node.get("all_player_hands") != null and world_node.all_player_hands.has(old_id):
+				world_node.all_player_hands[new_id] = world_node.all_player_hands[old_id]
+				world_node.all_player_hands.erase(old_id)
+			
+			if world_node.get("sorted_players") != null:
+				var idx = world_node.sorted_players.find(old_id)
+				if idx != -1:
+					world_node.sorted_players[idx] = new_id
 
 func disconnect_network():
 	# Explicitly close the ENet connection so the server knows we left
@@ -336,6 +452,20 @@ func join_game(ip, new_player_name):
 	if not multiplayer.is_server():
 		emit_signal("join_accepted_signal")
 
+@rpc("authority", "call_local") func push_full_gamestate(state_package: Dictionary):
+	if not multiplayer.is_server():
+		players = state_package["players"]
+		player_icon = state_package["player_icon"]
+		lydia_lion = state_package["lydia_lion"]
+		alloys = state_package["alloys"]
+		footprint_tiles = state_package["footprint_tiles"]
+		wellness_beads = state_package["wellness_beads"]
+		elcitraps = state_package["elcitraps"]
+		
+		is_hot_joining = true
+		game_in_progress = true
+		emit_signal("hot_join_accepted_signal")
+
 @rpc("authority", "call_local") func join_rejected(reason: String):
 	disconnect_network()
 	emit_signal("game_error", reason)
@@ -390,9 +520,9 @@ func get_tutorial_mode():
 
 func end_game():
 	game_in_progress = false
-	if has_node("/root/World"): # Game is in progress.
+	if has_node("/root/Manager"): # Game is in progress.
 		# End it
-		get_node("/root/World").queue_free()
+		get_node("/root/Manager").queue_free()
 
 	emit_signal("game_ended")
 	players.clear()

--- a/Scenes/Core/Lobby.gd
+++ b/Scenes/Core/Lobby.gd
@@ -27,6 +27,7 @@ func _ready():
 	gamestate.connect("player_list_changed", Callable(self, "refresh_lobby"))
 	gamestate.connection_failed.connect(_on_connection_failed)
 	gamestate.join_accepted_signal.connect(_on_join_accepted)
+	gamestate.hot_join_accepted_signal.connect(_on_hot_join_accepted)
 	gamestate.game_error.connect(_on_game_error)
 	
 	# Listen for the back button being clicked so we can cleanly disconnect
@@ -99,6 +100,15 @@ func _on_join_accepted():
 	
 	set_player_icon(selected_icon)
 	_update_start_button_state()
+
+func _on_hot_join_accepted():
+	set_error_label("")
+	
+	# Assume DominoWorld as the first level for a hot join
+	gamestate.first_level = "DominoWorld"
+	
+	var world = load("res://Scenes/Core/Manager.tscn")
+	get_tree().change_scene_to_packed(world)
 
 
 func _on_connection_failed():

--- a/Scenes/Level_4_DominoWorld/DominoWorld.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.gd
@@ -35,7 +35,7 @@ var tower = load(ReferenceManager.get_reference("Tower.gd"))
 var sorted_players = []
 var turn = 0
 var hand = []
-var dominos = [] + gamestate.dominos
+var dominos = gamestate.dominos.duplicate(true)
 var self_num = 0
 var selected_domino = null
 var center_num = 0
@@ -58,6 +58,7 @@ var prev_domino_size = 0
 var _next_slot_indicators: Array[Node2D] = []
 var bonusWords = ["Bonus", "Bonus2"]
 var usedBonus = ["ABC123"]
+var placement_history = []
 
 
 func _ready() -> void:
@@ -73,6 +74,10 @@ func _ready() -> void:
 	if center_area:
 		center_area.input_pickable = false
 		center_area.monitoring = false
+		
+	if gamestate.is_hot_joining:
+		gamestate.is_hot_joining = false
+		rpc_id(1, "request_full_state_sync")
 
 # Sets up and resolves players and their resulting nodes
 func _init_players() -> void:
@@ -353,7 +358,7 @@ func _on_Start_pressed() -> void:
 	SFXController.playSFX(ReferenceManager.get_reference("next.wav"))
 
 func randomize_turn():
-	turn = randi() % gamestate.players.size()
+	turn = randi() % sorted_players.size()
 	rpc("sync_turn", turn)
 	sync_turn(turn)
 
@@ -620,6 +625,7 @@ func place_domino(num):
 
 		# Broadcast the exact placement to everyone
 		rpc("update_domino_path", [true_bot, true_top], [bot_el, top_el], position_table[num], num, flip)
+		placement_history.append([[true_bot, true_top], [bot_el, top_el], position_table[num], num, flip])
 
 		hand_dominos.erase([placed_domino.top_num, placed_domino.bottom_num])
 		hand_dominos.erase([placed_domino.bottom_num, placed_domino.top_num])
@@ -646,6 +652,13 @@ func place_domino(num):
 			rpc("advance_turn")
 			advance_turn()
 			can_place = true
+			
+		if hand_dominos.size() == 0:
+			# Automatically synchronize next round when hand is empty!
+			if multiplayer.is_server():
+				_host_force_next_round()
+			else:
+				rpc_id(1, "_host_force_next_round")
 
 @rpc("any_peer", "call_local") func set_train_open(num: int, is_open: bool):
 	train_open[num] = is_open
@@ -898,6 +911,7 @@ func replace_domino():
 	num_placed = 0
 	_consecutive_help_count = 0
 	all_player_hands.clear()
+	placement_history.clear()
 	path_step_count = [0, 0, 0, 0, 0, 0, 0, 0]
 	var group_dominos = get_tree().get_nodes_in_group("dominos")
 	clear_selected_domino()
@@ -920,7 +934,7 @@ func replace_domino():
 		center_num += 1
 		_round_advancing = false
 		return
-	dominos = [] + gamestate.dominos
+	dominos = gamestate.dominos.duplicate(true)
 	dominos.shuffle()
 	center_num += 1
 	SaveManager.Save["0"].Current_Round += 1
@@ -960,8 +974,9 @@ func replace_domino():
 				for child in get_children():
 					print("Found child node: ", child.name)
 	
-	# Set a new random player's turn
-	randomize_turn()
+	# Set a new random player's turn natively on the host
+	if multiplayer.is_server():
+		randomize_turn()
 	_round_advancing = false
 
 # Evaluates the CPU's hand and returns the best valid move
@@ -1046,8 +1061,6 @@ func _trigger_stalemate() -> void:
 	$UIElements/StalematePopup.visible = false
 	next_round()
 	_stalemate_in_progress = false  # Reset so future rounds can detect stalemate
-	if multiplayer.is_server() and center_num <= 9:
-		setup_dominos()
 	# Re-show Next button for the host after auto-advance completes
 	if multiplayer.is_server():
 		next_button.visible = true
@@ -1059,7 +1072,7 @@ func _trigger_stalemate() -> void:
 @rpc("any_peer") func advance_turn():
 	if _game_over:
 		return
-	turn = (turn + 1) % len(gamestate.players)
+	turn = (turn + 1) % sorted_players.size()
 	_update_turn_label()
 	if multiplayer.is_server() and _check_stalemate():
 		_trigger_stalemate()
@@ -1150,6 +1163,7 @@ func _execute_cpu_turn_async(cpu_id):
 			set_train_open(my_path_idx, false)
 			
 		rpc("update_domino_path", [true_bot, true_top], [bot_e, top_e], position_table[move.path_idx], move.path_idx, flip)
+		placement_history.append([[true_bot, true_top], [bot_e, top_e], position_table[move.path_idx], move.path_idx, flip])
 		update_domino_path([true_bot, true_top], [bot_e, top_e], position_table[move.path_idx], move.path_idx, flip)
 
 		# Per D-03: wait for slide animation to complete before continuing
@@ -1174,20 +1188,19 @@ func _execute_cpu_turn_async(cpu_id):
 func _on_Next_pressed() -> void:
 	if _game_over:
 		return
-	# reset field for host
-	next_round()
+		
 	can_place = true
 	help_button.visible = false
-
-	# reset field for everyone else
-	for p in gamestate.players:
-		if p != 1:
-			rpc_id(p, "next_round")
-
-	# get new dominos from deck
-	if center_num <= 9:
-		setup_dominos()
-		SFXController.playSFX(ReferenceManager.get_reference("next.wav"))
+	SFXController.playSFX(ReferenceManager.get_reference("next.wav"))
+	
+	if multiplayer.is_server():
+		# Simply broadcast the network refresh exactly once to all peers organically
+		rpc("next_round")
+		next_round()
+		
+		# get new dominos from deck
+		if center_num <= 9:
+			setup_dominos()
 
 func _on_Reset_pressed() -> void:
 	if multiplayer.is_server():
@@ -1447,3 +1460,67 @@ class _NextSlotIndicator extends Node2D:
 		var line_width := 35.0
 		draw_rect(rect, glow_color, false, line_width + 20.0)
 		draw_rect(rect, Color(_color.r, _color.g, _color.b, 0.5), false, line_width)
+
+@rpc("any_peer", "call_local") func request_full_state_sync():
+	if multiplayer.is_server():
+		var id = multiplayer.get_remote_sender_id()
+		var state = {
+			"center_num": center_num,
+			"turn": turn,
+			"sorted_players": sorted_players.duplicate(true),
+			"path_ends": path_ends.duplicate(true),
+			"train_open": train_open.duplicate(true),
+			"can_place": can_place,
+			"num_placed": num_placed,
+			"dominos": dominos.duplicate(true),
+			"placement_history": placement_history.duplicate(true),
+			"hand": all_player_hands[id].duplicate(true) if all_player_hands.has(id) else []
+		}
+		rpc_id(id, "receive_full_state_sync", state)
+
+@rpc("authority", "call_local") func receive_full_state_sync(state: Dictionary):
+	center_num = state["center_num"]
+	turn = state["turn"]
+	if state.has("sorted_players"):
+		sorted_players = state["sorted_players"]
+		
+		# Important: Recalculate our physical body-index so Hot Joiners don't permanently permanently 
+		# maintain the scrambled `.sort()` values initialized tentatively during `_ready()`
+		self_num = sorted_players.find(multiplayer.get_unique_id())
+		
+	path_ends = [center_num, center_num, center_num, center_num, center_num, center_num, center_num, center_num]
+	train_open = state["train_open"]
+	path_step_count = [0, 0, 0, 0, 0, 0, 0, 0]
+	can_place = state["can_place"]
+	num_placed = state["num_placed"]
+	dominos = state["dominos"]
+	placement_history = state["placement_history"]
+	
+	_update_turn_label()
+	
+	var domino_title = ReferenceManager.get_reference("dominos/" + str(center_num) + str(center_num) + ".png")
+	central_domino.get_node("Sprite2D").texture = load(domino_title)
+	central_domino.modulate.a = 1.0
+	central_domino.scale = Vector2(0.5, 0.5)
+	
+	for i in range(8):
+		_update_train_indicator(i, train_open[i])
+	footprint_tile_ring.show_round(center_num)
+	add_tower(center_num)
+		
+	for args in state["placement_history"]:
+		update_domino_path(args[0], args[1], args[2], args[3], args[4])
+		
+	if typeof(state["hand"]) == TYPE_ARRAY and state["hand"].size() > 0:
+		render_hand(state["hand"])
+
+@rpc("any_peer") func _host_force_next_round():
+	if multiplayer.is_server():
+		rpc("next_round")
+		next_round()
+		if center_num <= 9:
+			setup_dominos()
+		
+	next_button.visible = false
+	if is_instance_valid(start_button):
+		start_button.queue_free()

--- a/Scenes/Level_4_DominoWorld/DominoWorldTutorial.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorldTutorial.gd
@@ -14,7 +14,7 @@ var sorted_players = []
 
 var turn = 0  # whose turn is it, indexed from 0 on
 var hand = []
-var dominos = [] + gamestate.dominos
+var dominos = gamestate.dominos.duplicate(true)
 var self_num = 0  # player's number, indexed from 1 on
 var selected_domino = null  # currently selected domino
 var center_num = 0  # current round number
@@ -490,7 +490,7 @@ func replace_domino():
 		return
 
 	# randomize dominos
-	dominos = [] + gamestate.dominos
+	dominos = gamestate.dominos.duplicate(true)
 	dominos.shuffle()
 
 	# increment round number


### PR DESCRIPTION
First, prevent a player from joining a domino game with the same name as someone else. Then, when a player leaves a domino game (i.e., closes their window), instead of hanging or skipping them, replace them with a CPU that will play for them.

If a player attempts to (re)join an existing game, use their name to determine whether they were in the game already. If so, allow them to take control back from the CPU that replaced them. If not, give them an error to indicate that the game is already in progress, so it's too late to join.

Of course, the complexity of this change is such that about 3.5 hours of iterative testing and LLM improvement was needed to eliminate dozens of edge-case bugs. It is likely that some still remain, although it seems to be working fairly consistently now.