### PR TITLE
DEV-52: Domino Stalemate Unit Tests Failing

### DIFF
--- a/Scenes/Level_4_DominoWorld/DominoWorld.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.gd
@@ -1003,7 +1003,7 @@ func calculate_cpu_move(cpu_id):
 # True stalemate check: returns true if NO player has ANY valid move on ANY accessible path
 # Called on host only. Per D-09, reuses calculate_cpu_move matching logic.
 func _check_stalemate() -> bool:
-	if not multiplayer.is_server():
+	if multiplayer != null and not multiplayer.is_server():
 		return false
 	for idx in range(sorted_players.size()):
 		var pid = sorted_players[idx]

--- a/addons/gdUnit4/GdUnitRunner.cfg
+++ b/addons/gdUnit4/GdUnitRunner.cfg
@@ -7,18 +7,72 @@
 			"@subpath": "",
 			"assembly_location": "",
 			"attribute_index": -1,
-			"display_name": "test_input_event_drop_domino",
-			"fully_qualified_name": "test.unit.DominoUnitTest.test_input_event_drop_domino",
-			"guid": "42cbdbd9-7b1147d-7bddd3b-3e4ffb4468",
-			"line_number": 115,
+			"display_name": "test_check_stalemate_returns_true_when_no_valid_moves",
+			"fully_qualified_name": "test.unit.DominoWorldStalemateTest.test_check_stalemate_returns_true_when_no_valid_moves",
+			"guid": "073060f9-95ea4be-9bf923c-b3cd3863fb",
+			"line_number": 21,
 			"metadata": {
 
 			},
 			"require_godot_runtime": true,
-			"source_file": "res://test/unit/DominoUnitTest.gd",
-			"suite_name": "DominoUnitTest",
-			"suite_resource_path": "res://test/unit/DominoUnitTest.gd",
-			"test_name": "test_input_event_drop_domino"
+			"source_file": "res://test/unit/DominoWorldStalemateTest.gd",
+			"suite_name": "DominoWorldStalemateTest",
+			"suite_resource_path": "res://test/unit/DominoWorldStalemateTest.gd",
+			"test_name": "test_check_stalemate_returns_true_when_no_valid_moves"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_check_stalemate_returns_false_when_player_has_valid_move",
+			"fully_qualified_name": "test.unit.DominoWorldStalemateTest.test_check_stalemate_returns_false_when_player_has_valid_move",
+			"guid": "31a483e1-b4fd4d5-5966132-ac9380ff1e",
+			"line_number": 41,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://test/unit/DominoWorldStalemateTest.gd",
+			"suite_name": "DominoWorldStalemateTest",
+			"suite_resource_path": "res://test/unit/DominoWorldStalemateTest.gd",
+			"test_name": "test_check_stalemate_returns_false_when_player_has_valid_move"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_check_stalemate_returns_false_when_open_train_available",
+			"fully_qualified_name": "test.unit.DominoWorldStalemateTest.test_check_stalemate_returns_false_when_open_train_available",
+			"guid": "846cb1d8-1f14421-1a7796a-23d7971a33",
+			"line_number": 59,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://test/unit/DominoWorldStalemateTest.gd",
+			"suite_name": "DominoWorldStalemateTest",
+			"suite_resource_path": "res://test/unit/DominoWorldStalemateTest.gd",
+			"test_name": "test_check_stalemate_returns_false_when_open_train_available"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_consecutive_help_count_exists",
+			"fully_qualified_name": "test.unit.DominoWorldStalemateTest.test_consecutive_help_count_exists",
+			"guid": "32314d20-4544498-68a1831-41d3263afa",
+			"line_number": 86,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://test/unit/DominoWorldStalemateTest.gd",
+			"suite_name": "DominoWorldStalemateTest",
+			"suite_resource_path": "res://test/unit/DominoWorldStalemateTest.gd",
+			"test_name": "test_consecutive_help_count_exists"
 		}
 	],
 	"version": "5.0"


### PR DESCRIPTION
In the `_check_stalemate` function in `DominoWorld.gd`, I added a multiplayer null check before checking if the current user is the server to ensure unit tests can execute successfully. As a result, unit tests being run as part of GitHub Actions now pass.