### PR TITLE
DEV-55: Next Round Domino Hand Reset

### DIFF
--- a/Autoloads/gamestate.gd
+++ b/Autoloads/gamestate.gd
@@ -407,6 +407,7 @@ func prepare_client_deck(r_seed):
 	seed(r_seed)
 	dominoes.shuffle()
 
+
 @rpc("any_peer", "call_local", "reliable")
 func post_start_game():
 	var world = load("res://Scenes/Core/Manager.tscn")
@@ -487,7 +488,7 @@ func join_game(ip, new_player_name):
 # player sets their random seed
 @rpc("any_peer") func set_random_seed(rando_seed):
 	random_seed = rando_seed
-#	print("seed: ", random_seed)
+
 
 func get_player_list():
 	return players.values()

--- a/Scenes/Core/Lobby.gd
+++ b/Scenes/Core/Lobby.gd
@@ -171,12 +171,6 @@ func handle_level(level):
 	for top in range(10):
 		for bottom in range(top + 1):
 			gamestate.dominoes.append([bottom, top])
-
-	randomize()
-	gamestate.random_seed = randi() % 10000000
-	seed(gamestate.random_seed)
-
-	gamestate.dominoes.shuffle()
 	
 	# Set host username and ip address labels
 	waitroom_host_name.set_text("Host: " + get_player_name())

--- a/Scenes/Level_4_DominoWorld/DominoWorld.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.gd
@@ -349,6 +349,7 @@ func _on_Start_pressed() -> void:
 	
 	randomize_turn()
 	
+	dominoes.shuffle()
 	setup_dominoes()
 	start_button.queue_free()
 	

--- a/Scenes/Level_4_DominoWorld/DominoWorld.gd
+++ b/Scenes/Level_4_DominoWorld/DominoWorld.gd
@@ -652,13 +652,7 @@ func place_domino(num):
 			rpc("advance_turn")
 			advance_turn()
 			can_place = true
-			
-		if hand_dominoes.size() == 0:
-			# Automatically synchronize next round when hand is empty!
-			if multiplayer.is_server():
-				_host_force_next_round()
-			else:
-				rpc_id(1, "_host_force_next_round")
+
 
 @rpc("any_peer", "call_local") func set_train_open(num: int, is_open: bool):
 	train_open[num] = is_open
@@ -913,6 +907,7 @@ func replace_domino():
 	all_player_hands.clear()
 	placement_history.clear()
 	path_step_count = [0, 0, 0, 0, 0, 0, 0, 0]
+	train_open = [false, false, false, false, false, false, false, false]
 	var group_dominoes = get_tree().get_nodes_in_group("dominoes")
 	clear_selected_domino()
 	for domino in group_dominoes:
@@ -1063,6 +1058,8 @@ func _trigger_stalemate() -> void:
 	_stalemate_in_progress = false  # Reset so future rounds can detect stalemate
 	# Re-show Next button for the host after auto-advance completes
 	if multiplayer.is_server():
+		if center_num <= 9:
+			setup_dominoes()
 		next_button.visible = true
 
 @rpc("any_peer") func sync_turn(new_turn):


### PR DESCRIPTION
Fixed errors with stalemates and early round termination when a player's hand was emptied. Previously, the player's hand would not be replenished when going to the next round. In some cases, the board would not be cleared of its dominoes. Now, the player's hand is always replenished when going to the next round, the round does not terminate early when a player's hand is emptied, and the board is always cleared of its dominoes when going to the next round.

Additionally, some small changes were made to ensure dominoes were shuffled properly. Initially, domino shuffling was handled in `Lobbby.gd` instead of `DominoWorld.gd`. Player A's domino hand in Round 1 of Game 1 would be the same as Player A's domino hand in Round 1 of Game 2, as a result. This has been fixed to ensure each domino hand is random. 